### PR TITLE
presets: implement default preset

### DIFF
--- a/cmd/vendor/main.go
+++ b/cmd/vendor/main.go
@@ -1,7 +1,10 @@
 package main
 
-import "github.com/alevinval/vendor-go/pkg/cli"
+import (
+	"github.com/alevinval/vendor-go/pkg/cli"
+	"github.com/alevinval/vendor-go/pkg/govendor"
+)
 
 func main() {
-	cli.Run()
+	cli.NewVendorCmd("vendor", &govendor.DefaultPreset{}).Execute()
 }

--- a/internal/utils/sets.go
+++ b/internal/utils/sets.go
@@ -1,0 +1,20 @@
+package utils
+
+import "sort"
+
+func Union(a, b []string) []string {
+	union := map[string]struct{}{}
+	for i := range a {
+		union[a[i]] = struct{}{}
+	}
+	for i := range b {
+		union[b[i]] = struct{}{}
+	}
+
+	list := make([]string, 0, len(union))
+	for key := range union {
+		list = append(list, key)
+	}
+	sort.Strings(list)
+	return list
+}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -178,7 +178,3 @@ func NewVendorCmd(commandName string, preset govendor.Preset) *cobra.Command {
 	rootCmd.AddCommand(newUpdateCmd(wrapper))
 	return rootCmd
 }
-
-func Run() error {
-	return NewVendorCmd("vendor", nil).Execute()
-}

--- a/pkg/govendor/presets.go
+++ b/pkg/govendor/presets.go
@@ -1,9 +1,37 @@
 package govendor
 
+var _ Preset = (*DefaultPreset)(nil)
+
+// Preset interface used to customize the behaviour of the vendor library.
+// It allows customizing anything you need, like the names of the spec and
+// lock file, also allows customizing the targeted and ignored paths.
 type Preset interface {
 	GetSpecFilename() string
 	GetSpecLockFilename() string
 	GetExtensions() []string
 	GetTargets(dep *Dependency) []string
 	GetIgnores(dep *Dependency) []string
+}
+
+// DefaultPreset provides the default configuration for the vendor library.
+type DefaultPreset struct{}
+
+func (dp *DefaultPreset) GetSpecFilename() string {
+	return SPEC_FILENAME
+}
+
+func (dp *DefaultPreset) GetSpecLockFilename() string {
+	return SPEC_LOCK_FILENAME
+}
+
+func (dp *DefaultPreset) GetExtensions() []string {
+	return []string{}
+}
+
+func (dp *DefaultPreset) GetTargets(dep *Dependency) []string {
+	return []string{}
+}
+
+func (dp *DefaultPreset) GetIgnores(dep *Dependency) []string {
+	return []string{}
 }

--- a/pkg/govendor/presets_test.go
+++ b/pkg/govendor/presets_test.go
@@ -1,0 +1,17 @@
+package govendor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultPreset(t *testing.T) {
+	sut := DefaultPreset{}
+
+	assert.Equal(t, ".vendor.yml", sut.GetSpecFilename())
+	assert.Equal(t, ".vendor-lock.yml", sut.GetSpecLockFilename())
+	assert.Empty(t, sut.GetExtensions())
+	assert.Empty(t, sut.GetTargets(nil))
+	assert.Empty(t, sut.GetIgnores(nil))
+}

--- a/pkg/govendor/spec_test.go
+++ b/pkg/govendor/spec_test.go
@@ -1,12 +1,43 @@
 package govendor
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSpecAdd(t *testing.T) {
+var _ Preset = (*TestPreset)(nil)
+
+type TestPreset struct {
+	*DefaultPreset
+}
+
+func (tp *TestPreset) GetExtensions() []string {
+	return []string{"md", "java"}
+}
+
+func (tp *TestPreset) GetTargets(dep *Dependency) []string {
+	target := fmt.Sprintf("preset-target-for-%s", dep.URL)
+	return []string{target}
+}
+
+func (tp *TestPreset) GetIgnores(dep *Dependency) []string {
+	ignore := fmt.Sprintf("preset-ignore-for-%s", dep.URL)
+	return []string{ignore}
+}
+
+func TestNewSpec_LoadsPreset(t *testing.T) {
+	spec := NewSpec(&TestPreset{})
+
+	assert.Equal(t, ".vendor.yml", spec.Preset.GetSpecFilename())
+	assert.Equal(t, ".vendor-lock.yml", spec.Preset.GetSpecLockFilename())
+	assert.Equal(t, []string{"java", "md"}, spec.Extensions)
+	assert.Equal(t, []string{}, spec.Targets)
+	assert.Equal(t, []string{}, spec.Ignores)
+}
+
+func TestSpecAdd_AddsDeps(t *testing.T) {
 	sut := NewSpec(nil)
 	assert.Empty(t, sut.Deps)
 
@@ -16,17 +47,20 @@ func TestSpecAdd(t *testing.T) {
 	assert.Equal(t, []*Dependency{dep}, sut.Deps)
 }
 
-func TestSpecAddUpdates(t *testing.T) {
+func TestSpecAdd_WhenDepAlreadyPresent_UpdatesExistingDep(t *testing.T) {
 	dep := NewDependency("some-url", "some-branch")
-	sut := NewSpec(nil)
-	sut.Deps = append(sut.Deps, dep)
+	dep.Targets = []string{"to-be-overwritten-target"}
+	dep.Ignores = []string{"to-be-overwritten-ignore"}
 
-	assert.Equal(t, []string{}, sut.Deps[0].Targets)
+	sut := NewSpec(&TestPreset{})
+	sut.Deps = append(sut.Deps, dep)
 
 	other := NewDependency("some-url", "other-branch")
 	other.Targets = []string{"other-target"}
+	other.Ignores = []string{"other-ignore"}
 	sut.Add(other)
 
 	assert.Equal(t, []*Dependency{dep}, sut.Deps)
-	assert.Equal(t, []string{"other-target"}, sut.Deps[0].Targets)
+	assert.Equal(t, []string{"other-target", "preset-target-for-some-url"}, sut.Deps[0].Targets)
+	assert.Equal(t, []string{"other-ignore", "preset-ignore-for-some-url"}, sut.Deps[0].Ignores)
 }


### PR DESCRIPTION
- Add a default fallback whenever a spec is loaded without preset, add a warning log trace as well.

- Update `applyPreset` to apply always, since preset should never be nil due to the default fallback.

- Apply preset after adding a new dependency.

- Preset application now respects extra entries being added, to avoid duplicate entries it does a sorted union.

Addresses #6 