### PR TITLE
spec: serialize preset names

### DIFF
--- a/example/.vendor.yml
+++ b/example/.vendor.yml
@@ -1,4 +1,5 @@
 version: 0.0.1
+preset: default
 vendor_dir: vendor/
 extensions:
   - proto

--- a/internal/wrapper.go
+++ b/internal/wrapper.go
@@ -10,22 +10,6 @@ func WrapPreset(preset govendor.Preset) *PresetWrapper {
 	return &PresetWrapper{preset}
 }
 
-func (w *PresetWrapper) GetSpecFilename() string {
-	if w.Preset == nil {
-		return govendor.SPEC_FILENAME
-	} else {
-		return w.Preset.GetSpecFilename()
-	}
-}
-
-func (w *PresetWrapper) GetSpecLockFilename() string {
-	if w.Preset == nil {
-		return govendor.SPEC_FILENAME
-	} else {
-		return w.Preset.GetSpecLockFilename()
-	}
-}
-
 func (w *PresetWrapper) LoadSpec() (*govendor.Spec, error) {
 	return govendor.LoadSpec(w)
 }

--- a/internal/wrapper.go
+++ b/internal/wrapper.go
@@ -11,13 +11,13 @@ func WrapPreset(preset govendor.Preset) *PresetWrapper {
 }
 
 func (w *PresetWrapper) LoadSpec() (*govendor.Spec, error) {
-	return govendor.LoadSpec(w)
+	return govendor.LoadSpec(w.Preset)
 }
 
 func (w *PresetWrapper) LoadSpecLock() (*govendor.SpecLock, error) {
-	return govendor.LoadSpecLock(w)
+	return govendor.LoadSpecLock(w.Preset)
 }
 
 func (w *PresetWrapper) NewSpec() *govendor.Spec {
-	return govendor.NewSpec(w)
+	return govendor.NewSpec(w.Preset)
 }

--- a/pkg/govendor/presets.go
+++ b/pkg/govendor/presets.go
@@ -6,6 +6,7 @@ var _ Preset = (*DefaultPreset)(nil)
 // It allows customizing anything you need, like the names of the spec and
 // lock file, also allows customizing the targeted and ignored paths.
 type Preset interface {
+	GetPresetName() string
 	GetSpecFilename() string
 	GetSpecLockFilename() string
 	GetExtensions() []string
@@ -15,6 +16,10 @@ type Preset interface {
 
 // DefaultPreset provides the default configuration for the vendor library.
 type DefaultPreset struct{}
+
+func (dp *DefaultPreset) GetPresetName() string {
+	return "default"
+}
 
 func (dp *DefaultPreset) GetSpecFilename() string {
 	return SPEC_FILENAME

--- a/pkg/govendor/presets_test.go
+++ b/pkg/govendor/presets_test.go
@@ -9,6 +9,7 @@ import (
 func TestDefaultPreset(t *testing.T) {
 	sut := DefaultPreset{}
 
+	assert.Equal(t, "default", sut.GetPresetName())
 	assert.Equal(t, ".vendor.yml", sut.GetSpecFilename())
 	assert.Equal(t, ".vendor-lock.yml", sut.GetSpecLockFilename())
 	assert.Empty(t, sut.GetExtensions())

--- a/pkg/govendor/spec.go
+++ b/pkg/govendor/spec.go
@@ -19,12 +19,13 @@ var logger = log.GetLogger()
 
 type Spec struct {
 	Version    string
+	Preset     string        `yaml:"preset"`
 	VendorDir  string        `yaml:"vendor_dir,omitempty"`
 	Extensions []string      `yaml:"extensions,omitempty"`
 	Targets    []string      `yaml:"targets,omitempty"`
 	Ignores    []string      `yaml:"ignores,omitempty"`
 	Deps       []*Dependency `yaml:"deps"`
-	Preset     Preset        `yaml:"-"`
+	preset     Preset        `yaml:"-"`
 }
 
 func LoadSpec(preset Preset) (*Spec, error) {
@@ -74,7 +75,7 @@ func (s *Spec) Add(dependency *Dependency) {
 	} else {
 		s.Deps = append(s.Deps, dependency)
 	}
-	s.applyPreset(s.Preset)
+	s.applyPreset(s.preset)
 }
 
 func (s *Spec) Save() error {
@@ -83,15 +84,16 @@ func (s *Spec) Save() error {
 		return err
 	}
 
-	return os.WriteFile(s.Preset.GetSpecFilename(), data, os.ModePerm)
+	return os.WriteFile(s.preset.GetSpecFilename(), data, os.ModePerm)
 }
 
 func (s *Spec) applyPreset(preset Preset) {
-	s.Preset = preset
-	s.Extensions = utils.Union(s.Extensions, s.Preset.GetExtensions())
+	s.preset = preset
+	s.Preset = preset.GetPresetName()
+	s.Extensions = utils.Union(s.Extensions, s.preset.GetExtensions())
 	for _, dep := range s.Deps {
-		dep.Targets = utils.Union(dep.Targets, s.Preset.GetTargets(dep))
-		dep.Ignores = utils.Union(dep.Ignores, s.Preset.GetIgnores(dep))
+		dep.Targets = utils.Union(dep.Targets, s.preset.GetTargets(dep))
+		dep.Ignores = utils.Union(dep.Ignores, s.preset.GetIgnores(dep))
 	}
 }
 

--- a/pkg/govendor/spec.go
+++ b/pkg/govendor/spec.go
@@ -29,10 +29,7 @@ type Spec struct {
 }
 
 func LoadSpec(preset Preset) (*Spec, error) {
-	if preset == nil {
-		logger.Warnf("no preset has been provided, using default preset")
-		preset = &DefaultPreset{}
-	}
+	preset = checkPreset(preset)
 
 	data, err := os.ReadFile(preset.GetSpecFilename())
 	if err != nil {
@@ -52,10 +49,7 @@ func LoadSpec(preset Preset) (*Spec, error) {
 }
 
 func NewSpec(preset Preset) *Spec {
-	if preset == nil {
-		logger.Warnf("no preset has been provided, using default preset")
-		preset = &DefaultPreset{}
-	}
+	preset = checkPreset(preset)
 
 	spec := &Spec{
 		Version:    VERSION,
@@ -104,4 +98,22 @@ func (s *Spec) findDep(dependency *Dependency) (*Dependency, bool) {
 		}
 	}
 	return nil, false
+}
+
+func checkPreset(preset Preset) Preset {
+	if preset == nil {
+		logger.Warnf("no preset has been provided, using default preset")
+		return &DefaultPreset{}
+	}
+
+	switch p := preset.(type) {
+	case *DefaultPreset:
+		break
+	default:
+		if p.GetPresetName() == "default" {
+			logger.Warnf("custom preset injected, but the name is \"default\" which is used for the default preset name, this will be confusing for users, consider a different name for your preset")
+		}
+	}
+
+	return preset
 }

--- a/pkg/govendor/spec_test.go
+++ b/pkg/govendor/spec_test.go
@@ -30,8 +30,7 @@ func (tp *TestPreset) GetIgnores(dep *Dependency) []string {
 func TestNewSpec_LoadsPreset(t *testing.T) {
 	spec := NewSpec(&TestPreset{})
 
-	assert.Equal(t, ".vendor.yml", spec.Preset.GetSpecFilename())
-	assert.Equal(t, ".vendor-lock.yml", spec.Preset.GetSpecLockFilename())
+	assert.Equal(t, &TestPreset{}, spec.preset)
 	assert.Equal(t, []string{"java", "md"}, spec.Extensions)
 	assert.Equal(t, []string{}, spec.Targets)
 	assert.Equal(t, []string{}, spec.Ignores)


### PR DESCRIPTION
- Serialise the name of the preset, this will be useful to know which preset was used to generate the spec

Relates to #8 