### PR TITLE
Address bugs

### DIFF
--- a/pkg/govendor/spec.go
+++ b/pkg/govendor/spec.go
@@ -17,7 +17,7 @@ const (
 var logger = log.GetLogger()
 
 type Spec struct {
-	Version    string
+	Version    string        `yaml:"version"`
 	PresetName string        `yaml:"preset"`
 	VendorDir  string        `yaml:"vendor_dir,omitempty"`
 	Filters    *Filters      `yaml:",inline"`

--- a/pkg/govendor/spec_lock.go
+++ b/pkg/govendor/spec_lock.go
@@ -19,22 +19,21 @@ func LoadSpecLock(preset Preset) (*SpecLock, error) {
 	fileName := preset.GetSpecLockFilename()
 	data, err := os.ReadFile(fileName)
 	if err != nil {
-		logger.Errorf("cannot read %s: %s", fileName, err)
-		return nil, err
+		return NewSpecLock(preset), nil
 	}
 
-	spec := &SpecLock{}
+	spec := NewSpecLock(preset)
 	err = yaml.Unmarshal(data, spec)
 	if err != nil {
 		logger.Errorf("cannot read %s: %s", fileName, err)
 		return nil, err
 	}
 
-	spec.preset = preset
 	return spec, nil
 }
 
 func NewSpecLock(preset Preset) *SpecLock {
+	preset = checkPreset(preset, false)
 	return &SpecLock{
 		Version: VERSION,
 		Deps:    []*DependencyLock{},

--- a/pkg/govendor/yaml_test.go
+++ b/pkg/govendor/yaml_test.go
@@ -1,0 +1,62 @@
+package govendor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpecYamlSerialization(t *testing.T) {
+	dep := NewDependency("some-url", "some-branch")
+	dep.Filters.
+		AddExtension("dep-extension").
+		AddTarget("dep-target").
+		AddIgnore("dep-ignore")
+	spec := NewSpec(&TestPreset{})
+	spec.Add(dep)
+
+	data, err := toYaml(spec)
+	assert.NoError(t, err)
+
+	expected := `version: 0.2.0
+preset: test-preset
+vendor_dir: vendor/
+extensions:
+  - preset-extension
+targets:
+  - preset-target
+ignores:
+  - preset-ignore
+deps:
+  - url: some-url
+    branch: some-branch
+    extensions:
+      - dep-extension
+      - preset-extension-for-some-url
+    targets:
+      - dep-target
+      - preset-target-for-some-url
+    ignores:
+      - dep-ignore
+      - preset-ignore-for-some-url
+`
+
+	assert.Equal(t, expected, string(data))
+}
+
+func TestSpecLockYamlSerialization(t *testing.T) {
+	dep := NewDependencyLock("some-url", "some-commit")
+	spec := NewSpecLock(&TestPreset{})
+	spec.Add(dep)
+
+	data, err := toYaml(spec)
+	assert.NoError(t, err)
+
+	expected := `version: 0.2.0
+deps:
+  - url: some-url
+    commit: some-commit
+`
+
+	assert.Equal(t, expected, string(data))
+}


### PR DESCRIPTION
- The lock file is not necessary, especiallycially when a repository has just been initialized but it has not installed yet the dependencies, therefore fallback to a default instance of the SpeckLock
- Ensure the preset is always checked on `NewSpecLock` to ensure it always falls back to the default preset if not
- Add YAML serialisation tests to easily spot when something changes the output format