### PR TITLE
preset: vendor dir customisation and forced filters

### DIFF
--- a/pkg/govendor/presets.go
+++ b/pkg/govendor/presets.go
@@ -6,11 +6,27 @@ var _ Preset = (*DefaultPreset)(nil)
 // It allows customizing anything you need, like the names of the spec and
 // lock file, also allows customizing the targeted and ignored paths.
 type Preset interface {
+	// GetPresetName returns the name for this preset
 	GetPresetName() string
+
+	// GetVendorDir returns the name for the vendor folder
+	GetVendorDir() string
+
+	// GetSpecFilename returns the name of the spec file
 	GetSpecFilename() string
+
+	// GetSpecLockFilename returns the name of the spec lock file
 	GetSpecLockFilename() string
+
+	// GetFilters returns the global filters of the preset
 	GetFilters() *Filters
+
+	// GetFiltersForDependency returns the specific filters for a dependency
 	GetFiltersForDependency(*Dependency) *Filters
+
+	// ForceFilters flag returns wether the preset will force the overriding of
+	// the spec or dependency filters to the preset ones
+	ForceFilters() bool
 }
 
 // DefaultPreset provides the default configuration for the vendor library.
@@ -18,6 +34,10 @@ type DefaultPreset struct{}
 
 func (dp *DefaultPreset) GetPresetName() string {
 	return "default"
+}
+
+func (dp *DefaultPreset) GetVendorDir() string {
+	return "vendor/"
 }
 
 func (dp *DefaultPreset) GetSpecFilename() string {
@@ -34,4 +54,8 @@ func (dp *DefaultPreset) GetFilters() *Filters {
 
 func (dp *DefaultPreset) GetFiltersForDependency(*Dependency) *Filters {
 	return NewFilters()
+}
+
+func (dp *DefaultPreset) ForceFilters() bool {
+	return false
 }

--- a/pkg/govendor/yaml_test.go
+++ b/pkg/govendor/yaml_test.go
@@ -20,7 +20,7 @@ func TestSpecYamlSerialization(t *testing.T) {
 
 	expected := `version: 0.2.0
 preset: test-preset
-vendor_dir: vendor/
+vendor_dir: test-vendor-dir
 extensions:
   - preset-extension
 targets:


### PR DESCRIPTION
- Adds support for vendor directory name customisation via preset
- Adds support for forcing the filters, this would override any user customization of the filters by the user.