### PR TITLE
preset: support customising the repository cache path

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"path"
 
 	"github.com/alevinval/vendor-go/internal"
 	"github.com/alevinval/vendor-go/internal/installers"
@@ -98,7 +97,7 @@ func newInstallCmd(wrapper *internal.PresetWrapper) *cobra.Command {
 				return
 			}
 
-			cache := path.Join(os.TempDir(), "vendor-go-cache")
+			cache := wrapper.GetCachePath()
 			logger.Infof("repository cache located at %s", cache)
 
 			m := installers.NewInstaller(cache, spec, specLock)
@@ -140,7 +139,7 @@ func newUpdateCmd(wrapper *internal.PresetWrapper) *cobra.Command {
 				return
 			}
 
-			cache := path.Join(os.TempDir(), "vendor-go-cache")
+			cache := wrapper.GetCachePath()
 			logger.Infof("repository cache located at %s", cache)
 
 			m := installers.NewInstaller(cache, spec, specLock)

--- a/pkg/govendor/presets.go
+++ b/pkg/govendor/presets.go
@@ -1,5 +1,10 @@
 package govendor
 
+import (
+	"os"
+	"path"
+)
+
 var _ Preset = (*DefaultPreset)(nil)
 
 // Preset interface used to customize the behaviour of the vendor library.
@@ -27,6 +32,9 @@ type Preset interface {
 	// ForceFilters flag returns wether the preset will force the overriding of
 	// the spec or dependency filters to the preset ones
 	ForceFilters() bool
+
+	// GetCachePath returns the path where the repository cache will be kept
+	GetCachePath() string
 }
 
 // DefaultPreset provides the default configuration for the vendor library.
@@ -58,4 +66,13 @@ func (dp *DefaultPreset) GetFiltersForDependency(*Dependency) *Filters {
 
 func (dp *DefaultPreset) ForceFilters() bool {
 	return false
+}
+
+func (dp *DefaultPreset) GetCachePath() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		logger.Warnf("Cannot find user HOME dir, using tempdir instead")
+		return os.TempDir()
+	}
+	return path.Join(homeDir, ".go-vendor-cache")
 }

--- a/pkg/govendor/spec_test.go
+++ b/pkg/govendor/spec_test.go
@@ -40,6 +40,10 @@ func (tp *TestPreset) ForceFilters() bool {
 	return tp.force
 }
 
+func (tp *TestPreset) GetCachePath() string {
+	return ".test-cache-path"
+}
+
 func (tp *TestPreset) GetFiltersForDependency(dep *Dependency) *Filters {
 	extension := fmt.Sprintf("preset-extension-for-%s", dep.URL)
 	target := fmt.Sprintf("preset-target-for-%s", dep.URL)


### PR DESCRIPTION
The default preset now attempts to use a user HOME path. If there is no user HOME, then fall back to OS tempdir.

Not sure if a warning should be logged when this happens. I've experienced cache corruption issues, in which git enters a broken state and cannot checkout branches or change the worktree.

Addresses #17 