### PR TITLE
git: reliable install and updates due to reliance on a forced reset

### DIFF
--- a/example/.vendor-lock.yml
+++ b/example/.vendor-lock.yml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.2.0
 deps:
   - url: https://github.com/alevinval/ledger
     commit: 04abf50e06ae0dcf88e75cb35e922c7ae3aefad6

--- a/internal/repository.go
+++ b/internal/repository.go
@@ -25,28 +25,20 @@ func (r *Repository) Path() string {
 	return r.path
 }
 
-func (r *Repository) CheckoutCommit(commit string) error {
-	return r.git.CheckoutCommit(commit, r.path)
-}
-
-func (r *Repository) CheckoutBranch(branch string) error {
-	return r.git.CheckoutBranch(branch, r.path)
-}
-
-func (r *Repository) Pull() error {
-	return r.git.Pull(r.path)
+func (r *Repository) Ensure() error {
+	return r.git.OpenOrClone(r.dep.URL, r.dep.Branch, r.path)
 }
 
 func (r *Repository) Fetch() error {
 	return r.git.Fetch(r.path)
 }
 
-func (r *Repository) GetCurrentCommit() (string, error) {
-	return r.git.GetCurrentCommit(r.path)
+func (r *Repository) Reset(refname string) error {
+	return r.git.Reset(r.path, refname)
 }
 
-func (r *Repository) Ensure() error {
-	return r.git.OpenOrClone(r.dep.URL, r.dep.Branch, r.path)
+func (r *Repository) GetCurrentCommit() (string, error) {
+	return r.git.GetCurrentCommit(r.path)
 }
 
 func (r *Repository) WalkDir(fn fs.WalkDirFunc) error {


### PR DESCRIPTION
This patch cleans up the git operations file, now it matches what we originally did on the `vendor-rs` tool. Now we rely on fetching and resetting the work tree. This ensures local changes are discarded and also lays the groundwork so in the future I can bring back the support for any kind of reference name in the dependencies of the spec, which now are constrained to being only branches. In the future, they will be able to be any kind of reference (tag, head, branch, commit...)

Should address #1 