### PR TITLE
orchestrator: add global cache locking mechanism

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/fatih/color v1.13.0
 	github.com/go-git/go-git/v5 v5.4.2
+	github.com/rogpeppe/go-internal v1.9.0
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.8.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/internal/lock.go
+++ b/internal/lock.go
@@ -1,0 +1,68 @@
+package internal
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/alevinval/vendor-go/pkg/log"
+	"github.com/rogpeppe/go-internal/lockedfile"
+)
+
+type Lock struct {
+	file *lockedfile.File
+	path string
+	warn string
+}
+
+func NewLock(path string) *Lock {
+	return &Lock{
+		path: path,
+	}
+}
+
+func (l *Lock) Acquire() (err error) {
+	ch := createLock(l.path)
+	l.file, err = l.doPoll(ch)
+	return
+}
+
+func (l *Lock) Release() error {
+	return l.file.Close()
+}
+
+func (l *Lock) WithWarn(warn string) *Lock {
+	l.warn = warn
+	return l
+}
+
+func (p *Lock) doPoll(ch <-chan *lockedfile.File) (*lockedfile.File, error) {
+	warn := p.warn != ""
+	for {
+		select {
+		case <-time.After(1 * time.Second):
+			if warn {
+				log.S().Warnf(p.warn)
+				warn = false
+			}
+		case lock, ok := <-ch:
+			if ok {
+				return lock, nil
+			} else {
+				return nil, fmt.Errorf("cannot acquire lock")
+			}
+		}
+	}
+}
+
+func createLock(path string) <-chan *lockedfile.File {
+	ch := make(chan *lockedfile.File)
+	go func() {
+		lock, err := lockedfile.Create(path)
+		if err != nil {
+			close(ch)
+			return
+		}
+		ch <- lock
+	}()
+	return ch
+}


### PR DESCRIPTION
Now, only one orchestrator can acquire to the cache during install or update operations. This should get rid of issues for multiple instances of the tool accessing the same cached repository, which can lead to incorrect vendoring results.

Other orchestrators now block until the GLOBAL_LOCK file can be acquired. If more than one second is spent waiting, a warning is logged for the user

Fixes #15 