### PR TITLE
internal/installer: use locking mechanism

### DIFF
--- a/internal/cache.go
+++ b/internal/cache.go
@@ -1,0 +1,47 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/alevinval/vendor-go/pkg/govendor"
+)
+
+const (
+	LOCKS_DIR = "locks"
+	REPOS_DIR = "repos"
+)
+
+func EnsureCacheDir(preset govendor.Preset) error {
+	cacheDir := preset.GetCacheDir()
+
+	err := os.MkdirAll(cacheDir, os.ModePerm)
+	if err != nil {
+		return ensureCacheErr(err)
+	}
+
+	os.MkdirAll(path.Join(cacheDir, LOCKS_DIR), os.ModePerm)
+	if err != nil {
+		return ensureCacheErr(err)
+	}
+
+	os.MkdirAll(path.Join(cacheDir, REPOS_DIR), os.ModePerm)
+	if err != nil {
+		return ensureCacheErr(err)
+	}
+
+	return nil
+}
+
+func getRepositoryPath(cacheDir string, dep *govendor.Dependency) string {
+	return path.Join(cacheDir, REPOS_DIR, dep.ID())
+}
+
+func getRepositoryLockPath(cacheDir string, dep *govendor.Dependency) string {
+	return path.Join(cacheDir, LOCKS_DIR, dep.ID())
+}
+
+func ensureCacheErr(err error) error {
+	return fmt.Errorf("cannot bootstrap cache: %w", err)
+}

--- a/internal/installers/dependency.go
+++ b/internal/installers/dependency.go
@@ -31,7 +31,13 @@ func newDependencyInstaller(spec *govendor.Spec, dep *govendor.Dependency, depLo
 }
 
 func (d *dependencyInstaller) Install() (*govendor.DependencyLock, error) {
-	err := d.repo.Ensure()
+	err := d.repo.Acquire()
+	if err != nil {
+		return nil, fmt.Errorf("cannot acquire repository lock: %w", err)
+	}
+	defer d.repo.Release()
+
+	err = d.repo.Ensure()
 	if err != nil {
 		return nil, fmt.Errorf("cannot ensure repository: %w", err)
 	}
@@ -59,7 +65,13 @@ func (d *dependencyInstaller) Install() (*govendor.DependencyLock, error) {
 }
 
 func (d *dependencyInstaller) Update() (*govendor.DependencyLock, error) {
-	err := d.repo.Ensure()
+	err := d.repo.Acquire()
+	if err != nil {
+		return nil, fmt.Errorf("cannot acquire repository lock: %w", err)
+	}
+	defer d.repo.Release()
+
+	err = d.repo.Ensure()
 	if err != nil {
 		return nil, fmt.Errorf("cannot open repository: %s", err)
 	}

--- a/internal/repository.go
+++ b/internal/repository.go
@@ -10,14 +10,16 @@ import (
 type Repository struct {
 	dep  *govendor.Dependency
 	git  *Git
+	lock *Lock
 	path string
 }
 
 func NewRepository(cacheDir string, dep *govendor.Dependency) *Repository {
 	return &Repository{
-		path: filepath.Join(cacheDir, dep.ID()),
 		dep:  dep,
 		git:  &Git{},
+		path: getRepositoryPath(cacheDir, dep),
+		lock: NewLock(getRepositoryLockPath(cacheDir, dep)),
 	}
 }
 
@@ -43,4 +45,12 @@ func (r *Repository) GetCurrentCommit() (string, error) {
 
 func (r *Repository) WalkDir(fn fs.WalkDirFunc) error {
 	return filepath.WalkDir(r.path, fn)
+}
+
+func (r *Repository) Acquire() error {
+	return r.lock.Acquire()
+}
+
+func (r *Repository) Release() error {
+	return r.lock.Release()
 }

--- a/pkg/cmd/orchestrator.go
+++ b/pkg/cmd/orchestrator.go
@@ -139,10 +139,15 @@ func (co *CmdOrchestrator) AddDependency(url, branch string) error {
 }
 
 func (co *CmdOrchestrator) getCacheLock() (*internal.Lock, error) {
+	err := internal.EnsureCacheDir(co.preset)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create cache: %w", err)
+	}
+
 	lockPath := path.Join(co.preset.GetCacheDir(), "LOCK")
 	lock := internal.NewLock(lockPath).
 		WithWarn("cannot acquire cache lock, are you running multiple instances in parallel?")
-	err := lock.Acquire()
+	err = lock.Acquire()
 	if err != nil {
 		return nil, fmt.Errorf("cannot acquire cache lock %q: %w", lockPath, err)
 	}


### PR DESCRIPTION
Installing or updating now acquires an individual lock on the repository This ensures that there's no competing access to the repository cache, thus avoiding inconsistent results. This patch opens the door to parallelizing the install and update process, eventually.

Fixes #35 