### PR TITLE
cmd/cleancache: implement command to reset the cache

### DIFF
--- a/internal/cache.go
+++ b/internal/cache.go
@@ -34,6 +34,14 @@ func EnsureCacheDir(preset govendor.Preset) error {
 	return nil
 }
 
+func ResetCacheDir(preset govendor.Preset) error {
+	err := os.RemoveAll(preset.GetCacheDir())
+	if err != nil {
+		return fmt.Errorf("cannot remove cache: %w", err)
+	}
+	return EnsureCacheDir(preset)
+}
+
 func getRepositoryPath(cacheDir string, dep *govendor.Dependency) string {
 	return path.Join(cacheDir, REPOS_DIR, dep.ID())
 }

--- a/pkg/cmd/commands.go
+++ b/pkg/cmd/commands.go
@@ -81,6 +81,19 @@ func newUpdateCmd(co *CmdOrchestrator) *cobra.Command {
 	}
 }
 
+func newCleanCacheCmd(co *CmdOrchestrator) *cobra.Command {
+	return &cobra.Command{
+		Use:   "cleancache",
+		Short: "resets the repository cache",
+		Run: func(cmd *cobra.Command, args []string) {
+			err := co.CleanCache()
+			if err != nil {
+				log.S().Errorf("%s", err)
+			}
+		},
+	}
+}
+
 func NewVendorCmd(commandName string, preset govendor.Preset) *cobra.Command {
 	rootCmd := newRootCmd(commandName)
 	rootCmd.PersistentFlags().BoolVarP(&isDebugEnabled, "debug", "d", false, "enable debug logging")
@@ -90,5 +103,6 @@ func NewVendorCmd(commandName string, preset govendor.Preset) *cobra.Command {
 	rootCmd.AddCommand(newAddCmd(orchestrator))
 	rootCmd.AddCommand(newInstallCmd(orchestrator))
 	rootCmd.AddCommand(newUpdateCmd(orchestrator))
+	rootCmd.AddCommand(newCleanCacheCmd(orchestrator))
 	return rootCmd
 }

--- a/pkg/cmd/orchestrator.go
+++ b/pkg/cmd/orchestrator.go
@@ -138,6 +138,14 @@ func (co *CmdOrchestrator) AddDependency(url, branch string) error {
 	return nil
 }
 
+func (co *CmdOrchestrator) CleanCache() error {
+	err := internal.ResetCacheDir(co.preset)
+	if err != nil {
+		return fmt.Errorf("cannot clean cache: %w", err)
+	}
+	return nil
+}
+
 func (co *CmdOrchestrator) getCacheLock() (*internal.Lock, error) {
 	err := internal.EnsureCacheDir(co.preset)
 	if err != nil {


### PR DESCRIPTION
Provides a new command to reset the cache folder, the command deletes all contents and then re-creates the expected folder structure. Resolves #2.