### PR TITLE
refactor: rename packages and reduce public API

### DIFF
--- a/cmd/vendor/main.go
+++ b/cmd/vendor/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"github.com/alevinval/vendor-go/pkg/cmd"
-	"github.com/alevinval/vendor-go/pkg/govendor"
+	"github.com/alevinval/vendor-go/pkg/vendor"
 )
 
 func main() {
-	cmd.NewVendorCmd("vendor", &govendor.DefaultPreset{}).Execute()
+	cmd.NewVendorCmd("vendor", &vendor.DefaultPreset{}).Execute()
 }

--- a/internal/cache.go
+++ b/internal/cache.go
@@ -13,7 +13,7 @@ const (
 	REPOS_DIR = "repos"
 )
 
-func EnsureCacheDir(preset govendor.Preset) error {
+func ensureCacheDir(preset govendor.Preset) error {
 	cacheDir := preset.GetCacheDir()
 
 	err := os.MkdirAll(cacheDir, os.ModePerm)
@@ -34,12 +34,12 @@ func EnsureCacheDir(preset govendor.Preset) error {
 	return nil
 }
 
-func ResetCacheDir(preset govendor.Preset) error {
+func resetCacheDir(preset govendor.Preset) error {
 	err := os.RemoveAll(preset.GetCacheDir())
 	if err != nil {
 		return fmt.Errorf("cannot remove cache: %w", err)
 	}
-	return EnsureCacheDir(preset)
+	return ensureCacheDir(preset)
 }
 
 func getRepositoryPath(cacheDir string, dep *govendor.Dependency) string {

--- a/internal/cache.go
+++ b/internal/cache.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/alevinval/vendor-go/pkg/govendor"
+	"github.com/alevinval/vendor-go/pkg/vendor"
 )
 
 const (
@@ -13,7 +13,7 @@ const (
 	REPOS_DIR = "repos"
 )
 
-func ensureCacheDir(preset govendor.Preset) error {
+func ensureCacheDir(preset vendor.Preset) error {
 	cacheDir := preset.GetCacheDir()
 
 	err := os.MkdirAll(cacheDir, os.ModePerm)
@@ -34,7 +34,7 @@ func ensureCacheDir(preset govendor.Preset) error {
 	return nil
 }
 
-func resetCacheDir(preset govendor.Preset) error {
+func resetCacheDir(preset vendor.Preset) error {
 	err := os.RemoveAll(preset.GetCacheDir())
 	if err != nil {
 		return fmt.Errorf("cannot remove cache: %w", err)
@@ -42,11 +42,11 @@ func resetCacheDir(preset govendor.Preset) error {
 	return ensureCacheDir(preset)
 }
 
-func getRepositoryPath(cacheDir string, dep *govendor.Dependency) string {
+func getRepositoryPath(cacheDir string, dep *vendor.Dependency) string {
 	return path.Join(cacheDir, REPOS_DIR, dep.ID())
 }
 
-func getRepositoryLockPath(cacheDir string, dep *govendor.Dependency) string {
+func getRepositoryLockPath(cacheDir string, dep *vendor.Dependency) string {
 	return path.Join(cacheDir, LOCKS_DIR, dep.ID())
 }
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -1,4 +1,4 @@
-package paths
+package importer
 
 import (
 	"fmt"
@@ -11,7 +11,7 @@ import (
 	"github.com/alevinval/vendor-go/pkg/log"
 )
 
-func ImportFileFunc(selector *Selector, srcRoot, dstRoot string) fs.WalkDirFunc {
+func WalkDirFunc(selector *Selector, srcRoot, dstRoot string) fs.WalkDirFunc {
 	return func(path string, _ os.DirEntry, err error) error {
 		if err != nil {
 			return fmt.Errorf("import interrupted: %w", err)

--- a/internal/importer/selector.go
+++ b/internal/importer/selector.go
@@ -1,4 +1,4 @@
-package paths
+package importer
 
 import (
 	"path/filepath"

--- a/internal/importer/selector.go
+++ b/internal/importer/selector.go
@@ -4,14 +4,14 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/alevinval/vendor-go/pkg/govendor"
+	"github.com/alevinval/vendor-go/pkg/vendor"
 )
 
 type Selector struct {
-	filters *govendor.Filters
+	filters *vendor.Filters
 }
 
-func NewSelector(spec *govendor.Spec, dep *govendor.Dependency) *Selector {
+func NewSelector(spec *vendor.Spec, dep *vendor.Dependency) *Selector {
 	filters := spec.Filters.Clone().ApplyFilters(dep.Filters)
 	return &Selector{
 		filters,

--- a/internal/importer/selector_test.go
+++ b/internal/importer/selector_test.go
@@ -3,19 +3,19 @@ package importer
 import (
 	"testing"
 
-	"github.com/alevinval/vendor-go/pkg/govendor"
+	"github.com/alevinval/vendor-go/pkg/vendor"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSelector(t *testing.T) {
-	spec := govendor.NewSpec(nil)
-	spec.Filters = govendor.NewFilters().
+	spec := vendor.NewSpec(nil)
+	spec.Filters = vendor.NewFilters().
 		AddExtension("spec-extension").
 		AddTarget("spec-target").
 		AddIgnore("spec-ignore")
 
-	dep := govendor.NewDependency("some-url", "some-branch")
-	dep.Filters = govendor.NewFilters().
+	dep := vendor.NewDependency("some-url", "some-branch")
+	dep.Filters = vendor.NewFilters().
 		AddExtension("dep-extension").
 		AddTarget("dep-target").
 		AddIgnore("dep-ignore")
@@ -25,7 +25,7 @@ func TestSelector(t *testing.T) {
 }
 
 func TestSelectorSelect(t *testing.T) {
-	filtersWithTargets := govendor.NewFilters().
+	filtersWithTargets := vendor.NewFilters().
 		AddExtension("proto").
 		AddTarget("target/a").
 		AddIgnore("ignored/a", "target/a/ignored")
@@ -33,7 +33,7 @@ func TestSelectorSelect(t *testing.T) {
 		filters: filtersWithTargets,
 	}
 
-	filtersWithoutTargets := govendor.NewFilters().
+	filtersWithoutTargets := vendor.NewFilters().
 		AddExtension("proto").
 		AddIgnore("ignored/a", "target/a/ignored")
 	sutWithoutTargets := Selector{

--- a/internal/importer/selector_test.go
+++ b/internal/importer/selector_test.go
@@ -1,4 +1,4 @@
-package paths
+package importer
 
 import (
 	"testing"

--- a/internal/installer.go
+++ b/internal/installer.go
@@ -1,10 +1,9 @@
-package installers
+package internal
 
 import (
 	"fmt"
 	"os"
 
-	"github.com/alevinval/vendor-go/internal"
 	"github.com/alevinval/vendor-go/pkg/govendor"
 	"github.com/alevinval/vendor-go/pkg/log"
 	"github.com/fatih/color"
@@ -36,7 +35,7 @@ func (in *Installer) run(action actionFunc) error {
 	resetVendorDir(in.spec.VendorDir)
 
 	for _, dep := range in.spec.Deps {
-		repo := internal.NewRepository(in.cacheDir, dep)
+		repo := NewRepository(in.cacheDir, dep)
 		lock, _ := in.lock.Find(dep.URL)
 		dependencyInstaller := newDependencyInstaller(in.spec, dep, lock, repo)
 

--- a/internal/installer.go
+++ b/internal/installer.go
@@ -4,18 +4,18 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/alevinval/vendor-go/pkg/govendor"
 	"github.com/alevinval/vendor-go/pkg/log"
+	"github.com/alevinval/vendor-go/pkg/vendor"
 	"github.com/fatih/color"
 )
 
 type Installer struct {
-	spec     *govendor.Spec
-	lock     *govendor.SpecLock
+	spec     *vendor.Spec
+	lock     *vendor.SpecLock
 	cacheDir string
 }
 
-func NewInstaller(cacheDir string, spec *govendor.Spec, lock *govendor.SpecLock) *Installer {
+func NewInstaller(cacheDir string, spec *vendor.Spec, lock *vendor.SpecLock) *Installer {
 	return &Installer{
 		cacheDir: cacheDir,
 		spec:     spec,
@@ -56,12 +56,12 @@ func resetVendorDir(vendorDir string) {
 	os.MkdirAll(vendorDir, os.ModePerm)
 }
 
-type actionFunc = func(*dependencyInstaller) (*govendor.DependencyLock, error)
+type actionFunc = func(*dependencyInstaller) (*vendor.DependencyLock, error)
 
-func installFunc(installer *dependencyInstaller) (*govendor.DependencyLock, error) {
+func installFunc(installer *dependencyInstaller) (*vendor.DependencyLock, error) {
 	return installer.Install()
 }
 
-func updateFunc(installer *dependencyInstaller) (*govendor.DependencyLock, error) {
+func updateFunc(installer *dependencyInstaller) (*vendor.DependencyLock, error) {
 	return installer.Update()
 }

--- a/internal/installer_dep.go
+++ b/internal/installer_dep.go
@@ -5,19 +5,19 @@ import (
 	"io/fs"
 
 	"github.com/alevinval/vendor-go/internal/importer"
-	"github.com/alevinval/vendor-go/pkg/govendor"
 	"github.com/alevinval/vendor-go/pkg/log"
+	"github.com/alevinval/vendor-go/pkg/vendor"
 	"github.com/fatih/color"
 )
 
 type dependencyInstaller struct {
-	dep             *govendor.Dependency
-	depLock         *govendor.DependencyLock
+	dep             *vendor.Dependency
+	depLock         *vendor.DependencyLock
 	repo            *Repository
 	importWalkDirFn fs.WalkDirFunc
 }
 
-func newDependencyInstaller(spec *govendor.Spec, dep *govendor.Dependency, depLock *govendor.DependencyLock, repo *Repository) *dependencyInstaller {
+func newDependencyInstaller(spec *vendor.Spec, dep *vendor.Dependency, depLock *vendor.DependencyLock, repo *Repository) *dependencyInstaller {
 	selector := importer.NewSelector(spec, dep)
 	importWalkDirFn := importer.WalkDirFunc(selector, repo.Path(), spec.VendorDir)
 
@@ -29,7 +29,7 @@ func newDependencyInstaller(spec *govendor.Spec, dep *govendor.Dependency, depLo
 	}
 }
 
-func (d *dependencyInstaller) Install() (*govendor.DependencyLock, error) {
+func (d *dependencyInstaller) Install() (*vendor.DependencyLock, error) {
 	err := d.repo.Acquire()
 	if err != nil {
 		return nil, fmt.Errorf("cannot acquire repository lock: %w", err)
@@ -63,7 +63,7 @@ func (d *dependencyInstaller) Install() (*govendor.DependencyLock, error) {
 	return d.importFiles()
 }
 
-func (d *dependencyInstaller) Update() (*govendor.DependencyLock, error) {
+func (d *dependencyInstaller) Update() (*vendor.DependencyLock, error) {
 	err := d.repo.Acquire()
 	if err != nil {
 		return nil, fmt.Errorf("cannot acquire repository lock: %w", err)
@@ -93,7 +93,7 @@ func (d *dependencyInstaller) Update() (*govendor.DependencyLock, error) {
 	return d.importFiles()
 }
 
-func (d *dependencyInstaller) importFiles() (*govendor.DependencyLock, error) {
+func (d *dependencyInstaller) importFiles() (*vendor.DependencyLock, error) {
 	err := d.repo.WalkDir(d.importWalkDirFn)
 	if err != nil {
 		return nil, fmt.Errorf("cannot import files: %w", err)
@@ -104,5 +104,5 @@ func (d *dependencyInstaller) importFiles() (*govendor.DependencyLock, error) {
 		return nil, fmt.Errorf("cannot get current commit: %w", err)
 	}
 
-	return govendor.NewDependencyLock(d.dep.URL, commit), nil
+	return vendor.NewDependencyLock(d.dep.URL, commit), nil
 }

--- a/internal/installer_dep.go
+++ b/internal/installer_dep.go
@@ -1,32 +1,31 @@
-package installers
+package internal
 
 import (
 	"fmt"
 	"io/fs"
 
-	"github.com/alevinval/vendor-go/internal"
-	"github.com/alevinval/vendor-go/internal/paths"
+	"github.com/alevinval/vendor-go/internal/importer"
 	"github.com/alevinval/vendor-go/pkg/govendor"
 	"github.com/alevinval/vendor-go/pkg/log"
 	"github.com/fatih/color"
 )
 
 type dependencyInstaller struct {
-	dep           *govendor.Dependency
-	depLock       *govendor.DependencyLock
-	repo          *internal.Repository
-	importFilesFn fs.WalkDirFunc
+	dep             *govendor.Dependency
+	depLock         *govendor.DependencyLock
+	repo            *Repository
+	importWalkDirFn fs.WalkDirFunc
 }
 
-func newDependencyInstaller(spec *govendor.Spec, dep *govendor.Dependency, depLock *govendor.DependencyLock, repo *internal.Repository) *dependencyInstaller {
-	selector := paths.NewSelector(spec, dep)
-	importFilesFn := paths.ImportFileFunc(selector, repo.Path(), spec.VendorDir)
+func newDependencyInstaller(spec *govendor.Spec, dep *govendor.Dependency, depLock *govendor.DependencyLock, repo *Repository) *dependencyInstaller {
+	selector := importer.NewSelector(spec, dep)
+	importWalkDirFn := importer.WalkDirFunc(selector, repo.Path(), spec.VendorDir)
 
 	return &dependencyInstaller{
-		dep:           dep,
-		depLock:       depLock,
-		repo:          repo,
-		importFilesFn: importFilesFn,
+		dep:             dep,
+		depLock:         depLock,
+		repo:            repo,
+		importWalkDirFn: importWalkDirFn,
 	}
 }
 
@@ -95,7 +94,7 @@ func (d *dependencyInstaller) Update() (*govendor.DependencyLock, error) {
 }
 
 func (d *dependencyInstaller) importFiles() (*govendor.DependencyLock, error) {
-	err := d.repo.WalkDir(d.importFilesFn)
+	err := d.repo.WalkDir(d.importWalkDirFn)
 	if err != nil {
 		return nil, fmt.Errorf("cannot import files: %w", err)
 	}

--- a/internal/orchestrator.go
+++ b/internal/orchestrator.go
@@ -5,16 +5,16 @@ import (
 	"os"
 	"path"
 
-	"github.com/alevinval/vendor-go/pkg/govendor"
 	"github.com/alevinval/vendor-go/pkg/log"
+	"github.com/alevinval/vendor-go/pkg/vendor"
 	"github.com/fatih/color"
 )
 
 type CmdOrchestrator struct {
-	preset govendor.Preset
+	preset vendor.Preset
 }
 
-func NewOrchestrator(preset govendor.Preset) *CmdOrchestrator {
+func NewOrchestrator(preset vendor.Preset) *CmdOrchestrator {
 	return &CmdOrchestrator{preset}
 }
 
@@ -24,7 +24,7 @@ func (co *CmdOrchestrator) Init() error {
 		return fmt.Errorf("%q already exists? %w", co.preset.GetSpecFilename(), err)
 	}
 
-	spec := govendor.NewSpec(co.preset)
+	spec := vendor.NewSpec(co.preset)
 
 	err = spec.Save()
 	if err != nil {
@@ -42,12 +42,12 @@ func (co *CmdOrchestrator) Install() error {
 	}
 	defer lock.Release()
 
-	spec, err := govendor.LoadSpec(co.preset)
+	spec, err := vendor.LoadSpec(co.preset)
 	if err != nil {
 		return fmt.Errorf("cannot install: %w", err)
 	}
 
-	specLock, err := govendor.LoadSpecLock(co.preset)
+	specLock, err := vendor.LoadSpecLock(co.preset)
 	if err != nil {
 		return fmt.Errorf("cannot install: %w", err)
 	}
@@ -82,12 +82,12 @@ func (co *CmdOrchestrator) Update() error {
 	}
 	defer lock.Release()
 
-	spec, err := govendor.LoadSpec(co.preset)
+	spec, err := vendor.LoadSpec(co.preset)
 	if err != nil {
 		return fmt.Errorf("cannot update: %w", err)
 	}
 
-	specLock, err := govendor.LoadSpecLock(co.preset)
+	specLock, err := vendor.LoadSpecLock(co.preset)
 	if err != nil {
 		return fmt.Errorf("cannot update: %w", err)
 	}
@@ -116,12 +116,12 @@ func (co *CmdOrchestrator) Update() error {
 }
 
 func (co *CmdOrchestrator) AddDependency(url, branch string) error {
-	spec, err := govendor.LoadSpec(co.preset)
+	spec, err := vendor.LoadSpec(co.preset)
 	if err != nil {
 		return fmt.Errorf("cannot add dependency: %w", err)
 	}
 
-	dep := govendor.NewDependency(url, branch)
+	dep := vendor.NewDependency(url, branch)
 	spec.AddDependency(dep)
 
 	err = spec.Save()

--- a/internal/orchestrator.go
+++ b/internal/orchestrator.go
@@ -1,12 +1,10 @@
-package cmd
+package internal
 
 import (
 	"fmt"
 	"os"
 	"path"
 
-	"github.com/alevinval/vendor-go/internal"
-	"github.com/alevinval/vendor-go/internal/installers"
 	"github.com/alevinval/vendor-go/pkg/govendor"
 	"github.com/alevinval/vendor-go/pkg/log"
 	"github.com/fatih/color"
@@ -57,7 +55,7 @@ func (co *CmdOrchestrator) Install() error {
 	cacheDir := co.preset.GetCacheDir()
 	log.S().Infof("repository cache located at %s", cacheDir)
 
-	m := installers.NewInstaller(cacheDir, spec, specLock)
+	m := NewInstaller(cacheDir, spec, specLock)
 	err = m.Install()
 	if err != nil {
 		return fmt.Errorf("install failed: %w", err)
@@ -97,7 +95,7 @@ func (co *CmdOrchestrator) Update() error {
 	cacheDir := co.preset.GetCacheDir()
 	log.S().Infof("repository cache located at %s", cacheDir)
 
-	m := installers.NewInstaller(cacheDir, spec, specLock)
+	m := NewInstaller(cacheDir, spec, specLock)
 	err = m.Update()
 	if err != nil {
 		return fmt.Errorf("update failed: %w", err)
@@ -139,21 +137,21 @@ func (co *CmdOrchestrator) AddDependency(url, branch string) error {
 }
 
 func (co *CmdOrchestrator) CleanCache() error {
-	err := internal.ResetCacheDir(co.preset)
+	err := resetCacheDir(co.preset)
 	if err != nil {
 		return fmt.Errorf("cannot clean cache: %w", err)
 	}
 	return nil
 }
 
-func (co *CmdOrchestrator) getCacheLock() (*internal.Lock, error) {
-	err := internal.EnsureCacheDir(co.preset)
+func (co *CmdOrchestrator) getCacheLock() (*Lock, error) {
+	err := ensureCacheDir(co.preset)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create cache: %w", err)
 	}
 
 	lockPath := path.Join(co.preset.GetCacheDir(), "LOCK")
-	lock := internal.NewLock(lockPath).
+	lock := NewLock(lockPath).
 		WithWarn("cannot acquire cache lock, are you running multiple instances in parallel?")
 	err = lock.Acquire()
 	if err != nil {

--- a/internal/repository.go
+++ b/internal/repository.go
@@ -4,17 +4,17 @@ import (
 	"io/fs"
 	"path/filepath"
 
-	"github.com/alevinval/vendor-go/pkg/govendor"
+	"github.com/alevinval/vendor-go/pkg/vendor"
 )
 
 type Repository struct {
-	dep  *govendor.Dependency
+	dep  *vendor.Dependency
 	git  *Git
 	lock *Lock
 	path string
 }
 
-func NewRepository(cacheDir string, dep *govendor.Dependency) *Repository {
+func NewRepository(cacheDir string, dep *vendor.Dependency) *Repository {
 	return &Repository{
 		dep:  dep,
 		git:  &Git{},

--- a/pkg/cmd/commands.go
+++ b/pkg/cmd/commands.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/alevinval/vendor-go/internal"
-	"github.com/alevinval/vendor-go/pkg/govendor"
 	"github.com/alevinval/vendor-go/pkg/log"
+	"github.com/alevinval/vendor-go/pkg/vendor"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/spf13/cobra"
@@ -18,7 +18,7 @@ var (
 func newRootCmd(commandName string) *cobra.Command {
 	return &cobra.Command{
 		Use:   commandName,
-		Short: fmt.Sprintf("[%s] %s is a flexible and customizable vendoring tool", govendor.VERSION, commandName),
+		Short: fmt.Sprintf("[%s] %s is a flexible and customizable vendoring tool", vendor.VERSION, commandName),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if isDebugEnabled {
 				log.Level.SetLevel(zapcore.DebugLevel)
@@ -95,7 +95,7 @@ func newCleanCacheCmd(co *internal.CmdOrchestrator) *cobra.Command {
 	}
 }
 
-func NewVendorCmd(commandName string, preset govendor.Preset) *cobra.Command {
+func NewVendorCmd(commandName string, preset vendor.Preset) *cobra.Command {
 	rootCmd := newRootCmd(commandName)
 	rootCmd.PersistentFlags().BoolVarP(&isDebugEnabled, "debug", "d", false, "enable debug logging")
 

--- a/pkg/cmd/commands.go
+++ b/pkg/cmd/commands.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/alevinval/vendor-go/internal"
 	"github.com/alevinval/vendor-go/pkg/govendor"
 	"github.com/alevinval/vendor-go/pkg/log"
 	"go.uber.org/zap/zapcore"
@@ -26,7 +27,7 @@ func newRootCmd(commandName string) *cobra.Command {
 	}
 }
 
-func newInitCmd(co *CmdOrchestrator) *cobra.Command {
+func newInitCmd(co *internal.CmdOrchestrator) *cobra.Command {
 	return &cobra.Command{
 		Use:   "init",
 		Short: "initialises the current directory",
@@ -39,7 +40,7 @@ func newInitCmd(co *CmdOrchestrator) *cobra.Command {
 	}
 }
 
-func newAddCmd(co *CmdOrchestrator) *cobra.Command {
+func newAddCmd(co *internal.CmdOrchestrator) *cobra.Command {
 	return &cobra.Command{
 		Use:   "add [url] [branch]",
 		Short: "Add a new dependency to the spec",
@@ -55,7 +56,7 @@ func newAddCmd(co *CmdOrchestrator) *cobra.Command {
 	}
 }
 
-func newInstallCmd(co *CmdOrchestrator) *cobra.Command {
+func newInstallCmd(co *internal.CmdOrchestrator) *cobra.Command {
 	return &cobra.Command{
 		Use:   "install",
 		Short: "Installs dependencies respectring the lockfile",
@@ -68,7 +69,7 @@ func newInstallCmd(co *CmdOrchestrator) *cobra.Command {
 	}
 }
 
-func newUpdateCmd(co *CmdOrchestrator) *cobra.Command {
+func newUpdateCmd(co *internal.CmdOrchestrator) *cobra.Command {
 	return &cobra.Command{
 		Use:   "update",
 		Short: "update dependencies to the latest commit from the branch of the spec",
@@ -81,7 +82,7 @@ func newUpdateCmd(co *CmdOrchestrator) *cobra.Command {
 	}
 }
 
-func newCleanCacheCmd(co *CmdOrchestrator) *cobra.Command {
+func newCleanCacheCmd(co *internal.CmdOrchestrator) *cobra.Command {
 	return &cobra.Command{
 		Use:   "cleancache",
 		Short: "resets the repository cache",
@@ -98,7 +99,7 @@ func NewVendorCmd(commandName string, preset govendor.Preset) *cobra.Command {
 	rootCmd := newRootCmd(commandName)
 	rootCmd.PersistentFlags().BoolVarP(&isDebugEnabled, "debug", "d", false, "enable debug logging")
 
-	orchestrator := NewOrchestrator(preset)
+	orchestrator := internal.NewOrchestrator(preset)
 	rootCmd.AddCommand(newInitCmd(orchestrator))
 	rootCmd.AddCommand(newAddCmd(orchestrator))
 	rootCmd.AddCommand(newInstallCmd(orchestrator))

--- a/pkg/vendor/dependency.go
+++ b/pkg/vendor/dependency.go
@@ -1,4 +1,4 @@
-package govendor
+package vendor
 
 import (
 	"crypto/sha256"

--- a/pkg/vendor/dependency_test.go
+++ b/pkg/vendor/dependency_test.go
@@ -1,4 +1,4 @@
-package govendor
+package vendor
 
 import (
 	"testing"

--- a/pkg/vendor/filters.go
+++ b/pkg/vendor/filters.go
@@ -1,4 +1,4 @@
-package govendor
+package vendor
 
 import (
 	"sort"

--- a/pkg/vendor/filters_test.go
+++ b/pkg/vendor/filters_test.go
@@ -1,4 +1,4 @@
-package govendor
+package vendor
 
 import (
 	"testing"

--- a/pkg/vendor/presets.go
+++ b/pkg/vendor/presets.go
@@ -1,4 +1,4 @@
-package govendor
+package vendor
 
 import (
 	"os"

--- a/pkg/vendor/presets_test.go
+++ b/pkg/vendor/presets_test.go
@@ -1,4 +1,4 @@
-package govendor
+package vendor
 
 import (
 	"testing"

--- a/pkg/vendor/spec.go
+++ b/pkg/vendor/spec.go
@@ -1,4 +1,4 @@
-package govendor
+package vendor
 
 import (
 	"fmt"

--- a/pkg/vendor/spec_lock.go
+++ b/pkg/vendor/spec_lock.go
@@ -1,4 +1,4 @@
-package govendor
+package vendor
 
 import (
 	"fmt"

--- a/pkg/vendor/spec_lock_test.go
+++ b/pkg/vendor/spec_lock_test.go
@@ -1,4 +1,4 @@
-package govendor
+package vendor
 
 import (
 	"testing"

--- a/pkg/vendor/spec_test.go
+++ b/pkg/vendor/spec_test.go
@@ -1,4 +1,4 @@
-package govendor
+package vendor
 
 import (
 	"fmt"

--- a/pkg/vendor/yaml.go
+++ b/pkg/vendor/yaml.go
@@ -1,4 +1,4 @@
-package govendor
+package vendor
 
 import (
 	"bytes"

--- a/pkg/vendor/yaml_test.go
+++ b/pkg/vendor/yaml_test.go
@@ -1,4 +1,4 @@
-package govendor
+package vendor
 
 import (
 	"testing"


### PR DESCRIPTION
- refactor: bring back original `vendor` package name
- refactor: make orchestrator internal

Should address #5 