### PR TITLE
internal/installer: vendor dependencies in parallel

### DIFF
--- a/internal/installer.go
+++ b/internal/installer.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/alevinval/vendor-go/pkg/log"
 	"github.com/alevinval/vendor-go/pkg/vending"
@@ -24,30 +25,69 @@ func NewInstaller(cacheDir string, spec *vending.Spec, lock *vending.SpecLock) *
 }
 
 func (in *Installer) Install() error {
-	return in.run(installFunc)
+	return in.runInParallel(installFunc)
 }
 
 func (in *Installer) Update() error {
-	return in.run(updateFunc)
+	return in.runInParallel(updateFunc)
 }
 
-func (in *Installer) run(action actionFunc) error {
+func (in *Installer) runInParallel(action actionFunc) error {
 	resetVendorDir(in.spec.VendorDir)
 
+	N := len(in.spec.Deps)
+	out := make(chan *vending.DependencyLock, N)
+	errors := make(chan error, 1)
+	wg := &sync.WaitGroup{}
+	wg.Add(N)
+
 	for _, dep := range in.spec.Deps {
-		repo := NewRepository(in.cacheDir, dep)
-		lock, _ := in.lock.Find(dep.URL)
-		dependencyInstaller := newDependencyInstaller(in.spec, dep, lock, repo)
-
-		dependencyLock, err := action(dependencyInstaller)
-		if err != nil {
-			return fmt.Errorf("cannot complete action: %w", err)
-		}
-
-		log.S().Infof("  🔒 %s", color.YellowString(dependencyLock.Commit))
-		in.lock.AddDependencyLock(dependencyLock)
+		go in.runInBackground(wg, action, dep, out)
 	}
 
+	completed := make(chan struct{}, 1)
+	go func() {
+		wg.Wait()
+		close(completed)
+	}()
+
+	var isCompleted bool
+	for !isCompleted {
+		select {
+		case err := <-errors:
+			return err
+		case <-completed:
+			isCompleted = true
+		}
+	}
+
+	for N > 0 {
+		dependencyLock := <-out
+
+		log.S().Infof("locking %s\n  🔒 %s",
+			color.CyanString(dependencyLock.URL),
+			color.YellowString(dependencyLock.Commit),
+		)
+		in.lock.AddDependencyLock(dependencyLock)
+
+		N--
+	}
+
+	return nil
+}
+
+func (in *Installer) runInBackground(wg *sync.WaitGroup, action actionFunc, dep *vending.Dependency, out chan *vending.DependencyLock) error {
+	repo := NewRepository(in.cacheDir, dep)
+	lock, _ := in.lock.Find(dep.URL)
+	dependencyInstaller := newDependencyInstaller(in.spec, dep, lock, repo)
+
+	dependencyLock, err := action(dependencyInstaller)
+	if err != nil {
+		return fmt.Errorf("cannot complete action: %w", err)
+	}
+
+	out <- dependencyLock
+	wg.Done()
 	return nil
 }
 


### PR DESCRIPTION
Dependencies are now vendored in parallel, the speedup is quite noticeable, specially for update operations, since most of the time is spent fetching the remote, which is I/O bound.

Since the operations are no longer sequential, had to tune the output logging so that the user understands what is being vendored and locked.