### PR TITLE
pkg/log: remove useless Sync call

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -23,10 +23,9 @@ var (
 
 func init() {
 	logger = zap.Must(getDefaultCfg().Build())
-	defer logger.Sync()
 }
 
-// S returns the zap suggared logger from the current logger instance.
+// S returns the zap sugared logger from the current logger instance.
 func S() *zap.SugaredLogger {
 	return logger.Sugar()
 }


### PR DESCRIPTION
The defer will be executed right after the init block returns, nothing should panic at initialisation time, if it does it would be a bug that would be detected right at development.