### PR TITLE
spec-lock: rename Find to FindByURL

### DIFF
--- a/internal/installer.go
+++ b/internal/installer.go
@@ -78,7 +78,7 @@ func (in *Installer) runInParallel(action actionFunc) error {
 
 func (in *Installer) runInBackground(wg *sync.WaitGroup, action actionFunc, dep *vending.Dependency, out chan *vending.DependencyLock) error {
 	repo := NewRepository(in.cacheDir, dep)
-	lock, _ := in.lock.Find(dep.URL)
+	lock, _ := in.lock.FindByURL(dep.URL)
 	dependencyInstaller := newDependencyInstaller(in.spec, dep, lock, repo)
 
 	dependencyLock, err := action(dependencyInstaller)

--- a/pkg/vending/spec_lock.go
+++ b/pkg/vending/spec_lock.go
@@ -49,7 +49,7 @@ func NewSpecLock(preset Preset) *SpecLock {
 
 // AddDependencyLock adds a DependencyLock to the list of locked dependencies.
 func (s *SpecLock) AddDependencyLock(lock *DependencyLock) {
-	existing, ok := s.Find(lock.URL)
+	existing, ok := s.FindByURL(lock.URL)
 	if ok {
 		existing.Commit = lock.Commit
 	} else {
@@ -57,8 +57,8 @@ func (s *SpecLock) AddDependencyLock(lock *DependencyLock) {
 	}
 }
 
-// Find finds a DependencyLock by URL.
-func (s *SpecLock) Find(url string) (*DependencyLock, bool) {
+// FindByURL finds a DependencyLock by URL.
+func (s *SpecLock) FindByURL(url string) (*DependencyLock, bool) {
 	for _, dep := range s.Deps {
 		if strings.EqualFold(dep.URL, url) {
 			return dep, true


### PR DESCRIPTION
This name should age better, since this is precisely what this method is doing.