### PR TITLE
pkg/cmd: make use of options to customize command construction

### DIFF
--- a/cmd/vending/main.go
+++ b/cmd/vending/main.go
@@ -6,5 +6,8 @@ import (
 )
 
 func main() {
-	cmd.NewVendingCmd("vending", &vending.DefaultPreset{}).Execute()
+	cmd.NewCobraCommand(
+		cmd.WithCommandName("vending"),
+		cmd.WithPreset(&vending.DefaultPreset{}),
+	).Execute()
 }

--- a/pkg/cmd/opts.go
+++ b/pkg/cmd/opts.go
@@ -1,0 +1,24 @@
+package cmd
+
+import "github.com/alevinval/vendor-go/pkg/vending"
+
+// Option is used to apply customizations to the cmdBuilder.
+type Option = func(cb *cmdBuilder)
+
+// WithCommandName option customizes the name of the command.
+func WithCommandName(name string) Option {
+	return Option(
+		func(cb *cmdBuilder) {
+			cb.commandName = name
+		},
+	)
+}
+
+// WithPreset is used customizes the Preset that will be used.
+func WithPreset(preset vending.Preset) Option {
+	return Option(
+		func(b *cmdBuilder) {
+			b.preset = preset
+		},
+	)
+}


### PR DESCRIPTION
This breaks the API now, but it should make it more resilient to the passage of time and addition of new features. Also this will open the room to provide integrations for other CLI libraries, if we ever want to consider this.