### PR TITLE
spec: remove ID field which is only used for caching mechanisms

### DIFF
--- a/internal/cache.go
+++ b/internal/cache.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path"
@@ -43,13 +45,19 @@ func resetCacheDir(preset vending.Preset) error {
 }
 
 func getRepositoryPath(cacheDir string, dep *vending.Dependency) string {
-	return path.Join(cacheDir, REPOS_DIR, dep.ID())
+	return path.Join(cacheDir, REPOS_DIR, getDependencyID(dep))
 }
 
 func getRepositoryLockPath(cacheDir string, dep *vending.Dependency) string {
-	return path.Join(cacheDir, LOCKS_DIR, dep.ID())
+	return path.Join(cacheDir, LOCKS_DIR, getDependencyID(dep))
 }
 
 func ensureCacheErr(err error) error {
 	return fmt.Errorf("cannot bootstrap cache: %w", err)
+}
+
+func getDependencyID(dep *vending.Dependency) string {
+	sha := sha256.New()
+	data := sha.Sum([]byte(dep.URL))
+	return hex.EncodeToString(data)
 }

--- a/internal/cache_test.go
+++ b/internal/cache_test.go
@@ -1,0 +1,30 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/alevinval/vendor-go/pkg/vending"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCache_RepositoryPath(t *testing.T) {
+	dep := vending.NewDependency("some-url", "some-branch")
+
+	actual := getRepositoryPath("some-cache-root", dep)
+
+	assert.Equal(t,
+		"some-cache-root/repos/736f6d652d75726ce3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		actual,
+	)
+}
+
+func TestCache_RepositoryLockPath(t *testing.T) {
+	dep := vending.NewDependency("some-url", "some-branch")
+
+	actual := getRepositoryLockPath("some-cache-root", dep)
+
+	assert.Equal(t,
+		"some-cache-root/locks/736f6d652d75726ce3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		actual,
+	)
+}

--- a/pkg/vending/dependency.go
+++ b/pkg/vending/dependency.go
@@ -1,10 +1,5 @@
 package vending
 
-import (
-	"crypto/sha256"
-	"encoding/hex"
-)
-
 // Dependency holds relevant information related to a dependency that has to be
 // vendored. This model directly maps to the serialized YAML, for dependencies.
 type Dependency struct {
@@ -36,14 +31,6 @@ func NewDependencyLock(url, commit string) *DependencyLock {
 		URL:    url,
 		Commit: commit,
 	}
-}
-
-// ID returns the unique identifier for that dependency.
-// It returns the sha256 of the URL.
-func (d *Dependency) ID() string {
-	sha := sha256.New()
-	data := sha.Sum([]byte(d.URL))
-	return hex.EncodeToString(data)
 }
 
 // Update changes the URL, Branch and Filters fields of the dependency by the

--- a/pkg/vending/dependency_test.go
+++ b/pkg/vending/dependency_test.go
@@ -25,8 +25,3 @@ func TestDependencyUpdate(t *testing.T) {
 	assert.Equal(t, other.Filters.Targets, dep.Filters.Targets)
 	assert.Equal(t, other.Filters.Ignores, dep.Filters.Ignores)
 }
-
-func TestDependencyID(t *testing.T) {
-	dep := NewDependency("some-url", "some-branch")
-	assert.Equal(t, "736f6d652d75726ce3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", dep.ID())
-}


### PR DESCRIPTION
This seems like a problematic field to expose publicly, it does not help that we only use the ID to generate the folders in the cache, so let's move that logic in the `internal` package.