### PR TITLE
pkg/vending: moved YAML loading as methods of the spec and lock

### DIFF
--- a/internal/orchestrator.go
+++ b/internal/orchestrator.go
@@ -43,12 +43,14 @@ func (co *CmdOrchestrator) Install() error {
 	}
 	defer lock.Release()
 
-	spec, err := vending.LoadSpec(co.preset)
+	spec := vending.NewSpec(co.preset)
+	err = spec.Load()
 	if err != nil {
 		return fmt.Errorf("cannot install: %w", err)
 	}
 
-	specLock, err := vending.LoadSpecLock(co.preset)
+	specLock := vending.NewSpecLock(co.preset)
+	err = specLock.Load()
 	if err != nil {
 		return fmt.Errorf("cannot install: %w", err)
 	}
@@ -83,12 +85,14 @@ func (co *CmdOrchestrator) Update() error {
 	}
 	defer lock.Release()
 
-	spec, err := vending.LoadSpec(co.preset)
+	spec := vending.NewSpec(co.preset)
+	err = spec.Load()
 	if err != nil {
 		return fmt.Errorf("cannot update: %w", err)
 	}
 
-	specLock, err := vending.LoadSpecLock(co.preset)
+	specLock := vending.NewSpecLock(co.preset)
+	err = specLock.Load()
 	if err != nil {
 		return fmt.Errorf("cannot update: %w", err)
 	}
@@ -117,7 +121,8 @@ func (co *CmdOrchestrator) Update() error {
 }
 
 func (co *CmdOrchestrator) AddDependency(url, branch string) error {
-	spec, err := vending.LoadSpec(co.preset)
+	spec := vending.NewSpec(co.preset)
+	err := spec.Load()
 	if err != nil {
 		return fmt.Errorf("cannot add dependency: %w", err)
 	}

--- a/pkg/vending/spec.go
+++ b/pkg/vending/spec.go
@@ -25,26 +25,6 @@ type Spec struct {
 	preset     Preset        `yaml:"-"`
 }
 
-// LoadSpec loads a Spec given a Preset.
-func LoadSpec(preset Preset) (*Spec, error) {
-	preset = checkPreset(preset, true)
-
-	filename := preset.GetSpecFilename()
-	data, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, fmt.Errorf("cannot read: %w", err)
-	}
-
-	spec := &Spec{}
-	err = yaml.Unmarshal(data, spec)
-	if err != nil {
-		return nil, fmt.Errorf("cannot parse: %w", err)
-	}
-
-	spec.applyPreset(preset)
-	return spec, nil
-}
-
 // NewSpec allocates a new Spec instance with the default initialization.
 func NewSpec(preset Preset) *Spec {
 	preset = checkPreset(preset, true)
@@ -65,6 +45,25 @@ func (s *Spec) AddDependency(dependency *Dependency) {
 		s.Deps = append(s.Deps, dependency)
 	}
 	s.applyPreset(s.preset)
+}
+
+// Load Spec from the filesystem.
+func (s *Spec) Load() error {
+	preset := s.preset
+
+	filename := preset.GetSpecFilename()
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("cannot read: %w", err)
+	}
+
+	err = yaml.Unmarshal(data, s)
+	if err != nil {
+		return fmt.Errorf("cannot parse: %w", err)
+	}
+
+	s.applyPreset(preset)
+	return nil
 }
 
 // Save converts the Spec to YAML, and writes the data in the spec file,

--- a/pkg/vending/spec_lock_test.go
+++ b/pkg/vending/spec_lock_test.go
@@ -33,16 +33,16 @@ func TestSpecLock_BumpsVersion_WhenSpecIsOlder(t *testing.T) {
 	sut := NewSpecLock(&TestPreset{})
 	sut.Version = "v0.0.1"
 
-	sut.applyPreset()
+	sut.applyPreset(sut.preset)
 
 	assert.Equal(t, VERSION, sut.Version)
 }
 
 func TestSpecLock_DoesNotBumpVersion_WhenSpecIsNewer(t *testing.T) {
-	spec := NewSpec(&TestPreset{})
-	spec.Version = "v999.0.0"
+	sut := NewSpecLock(&TestPreset{})
+	sut.Version = "v999.0.0"
 
-	spec.applyPreset(&TestPreset{})
+	sut.applyPreset(sut.preset)
 
-	assert.Equal(t, "v999.0.0", spec.Version)
+	assert.Equal(t, "v999.0.0", sut.Version)
 }


### PR DESCRIPTION
Makes code a bit more straight-forward, still subject to change, loading the files feels a bit ad-hoc, plus the logic to ensure a default preset.