### PR TITLE
pkg/vending: simplify applyPreset method

### DIFF
--- a/pkg/vending/dependency.go
+++ b/pkg/vending/dependency.go
@@ -41,3 +41,7 @@ func (d *Dependency) Update(other *Dependency) {
 	d.Branch = other.Branch
 	d.Filters = other.Filters.Clone()
 }
+
+func (d *Dependency) applyPreset(preset Preset) {
+	d.Filters.ApplyDependencyPreset(preset, d)
+}

--- a/pkg/vending/filters.go
+++ b/pkg/vending/filters.go
@@ -59,15 +59,28 @@ func (f *Filters) ApplyFilters(filters *Filters) *Filters {
 
 // ApplyPreset applies the Filters of a Preset.
 func (f *Filters) ApplyPreset(preset Preset) *Filters {
+	if preset.ForceFilters() {
+		f.Clear()
+	}
 	return f.
 		ApplyFilters(preset.GetFilters())
 }
 
 // ApplyDep applies the filters of a Preset, and a Dependency.
-func (f *Filters) ApplyDep(preset Preset, dep *Dependency) *Filters {
+func (f *Filters) ApplyDependencyPreset(preset Preset, dep *Dependency) *Filters {
+	if preset.ForceFilters() {
+		f.Clear()
+	}
 	return f.
 		ApplyFilters(dep.Filters).
 		ApplyFilters(preset.GetFiltersForDependency(dep))
+}
+
+func (f *Filters) Clear() *Filters {
+	f.Extensions = []string{}
+	f.Targets = []string{}
+	f.Ignores = []string{}
+	return f
 }
 
 // Clone allocates a new instance, and clones the contents of the current one.

--- a/pkg/vending/filters_test.go
+++ b/pkg/vending/filters_test.go
@@ -50,7 +50,7 @@ func TestFilters_ApplyPresetDep_UpdatesWithUnion(t *testing.T) {
 		AddTarget("target-2").
 		AddIgnore("ignore-2")
 
-	sut.ApplyDep(&TestPreset{}, dep)
+	sut.ApplyDependencyPreset(&TestPreset{}, dep)
 
 	assert.Equal(t, []string{"ext-1", "ext-2", "preset-extension-for-some-url"}, sut.Extensions)
 	assert.Equal(t, []string{"preset-target-for-some-url", "target-1", "target-2"}, sut.Targets)
@@ -68,4 +68,17 @@ func TestFilters_Clone_ReturnsNewInstance(t *testing.T) {
 
 	clone.AddExtension("ext-2")
 	assert.NotEqual(t, sut, clone)
+}
+
+func TestFilters_Clear_ThenClearsLists(t *testing.T) {
+	sut := NewFilters().
+		AddExtension("ext-1").
+		AddTarget("target-1").
+		AddIgnore("ignore-1")
+
+	assert.NotEqual(t, NewFilters(), sut)
+
+	sut.Clear()
+
+	assert.Equal(t, NewFilters(), sut)
 }

--- a/pkg/vending/spec.go
+++ b/pkg/vending/spec.go
@@ -91,24 +91,9 @@ func (s *Spec) applyPreset(preset Preset) {
 		s.Version = VERSION
 	}
 
-	if preset.ForceFilters() {
-		s.Filters = preset.GetFilters()
-	} else {
-		if s.Filters == nil {
-			s.Filters = NewFilters()
-		}
-		s.Filters.ApplyPreset(preset)
-	}
-
+	s.Filters.ApplyPreset(preset)
 	for _, dep := range s.Deps {
-		if preset.ForceFilters() {
-			dep.Filters = preset.GetFiltersForDependency(dep)
-		} else {
-			if dep.Filters == nil {
-				dep.Filters = NewFilters()
-			}
-			dep.Filters.ApplyDep(preset, dep)
-		}
+		dep.applyPreset(preset)
 	}
 }
 


### PR DESCRIPTION
Now that loading the YAML can never happen with a nil preset, this logic can be simplified. Also make it more readable by clearly distinguishing the two paths, depending on whether forcing is enabled or not.