### PR TITLE
vending/dependency: fix nil issue

### DIFF
--- a/pkg/vending/dependency.go
+++ b/pkg/vending/dependency.go
@@ -43,5 +43,8 @@ func (d *Dependency) Update(other *Dependency) {
 }
 
 func (d *Dependency) applyPreset(preset Preset) {
+	if d.Filters == nil {
+		d.Filters = NewFilters()
+	}
 	d.Filters.ApplyDep(preset, d)
 }


### PR DESCRIPTION
Spec is always created with New, so filters are always initialised. However, dependencies are loaded by serialisation too, which means the Filters have to be checked and initialised if needed when applying the Preset.