### PR TITLE
internal/importer: skip unwanted directories

### DIFF
--- a/internal/importer/selector.go
+++ b/internal/importer/selector.go
@@ -19,8 +19,11 @@ func newSelector(spec *vending.Spec, dep *vending.Dependency) *Selector {
 	}
 }
 
-func (sel *Selector) Select(path string) bool {
-	return sel.isTarget(path) && sel.hasExt(path) && !sel.isIgnored(path)
+func (sel *Selector) Select(path string) (isSelected, isTarget, isIgnored, hasExt bool) {
+	isIgnored = sel.isIgnored(path)
+	isTarget = sel.isTarget(path)
+	hasExt = sel.hasExt(path)
+	return isTarget && hasExt && !isIgnored, isTarget, isIgnored, hasExt
 }
 
 func (sel *Selector) isTarget(path string) bool {


### PR DESCRIPTION
This patch optimizes the import procedure, by pruning directories that are either not targets, or that are ignored. This speeds the process since we do not have to traverse all files for directories that we don't care about.