### PR TITLE
internal/importer: fix bug when pruning directories

### DIFF
--- a/internal/importer/collector.go
+++ b/internal/importer/collector.go
@@ -34,7 +34,7 @@ func (tc *targetCollector) copyAll() error {
 }
 
 func (t *target) copy() error {
-	log.S().Debugf("  ..%s -> %s", t.srcRelative, t.dst)
+	log.S().Debugf("  [copy] ../%s -> %s", t.srcRelative, t.dst)
 
 	dstDir := filepath.Dir(t.dst)
 	err := os.MkdirAll(dstDir, os.ModePerm)

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/alevinval/vendor-go/internal/git"
+	"github.com/alevinval/vendor-go/pkg/log"
 	"github.com/alevinval/vendor-go/pkg/vending"
 )
 
@@ -81,6 +82,7 @@ func collectPathsFunc(srcRoot, dstRoot string, selector *Selector, collector *ta
 				},
 			)
 		} else if entry.IsDir() && !shouldEnterDir {
+			log.S().Debugf("  [skip] %s", relativePath)
 			return fs.SkipDir
 		}
 

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -1,0 +1,81 @@
+package importer
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/alevinval/vendor-go/internal/git"
+	"github.com/alevinval/vendor-go/internal/lock"
+	"github.com/alevinval/vendor-go/pkg/vending"
+	"github.com/stretchr/testify/assert"
+)
+
+const VENDOR_DIR = ".testvendor"
+const INPUT_DIR = ".testinput"
+
+func TestImporter_Import_VendorsFiles(t *testing.T) {
+	filters := vending.NewFilters().
+		AddExtension("txt").
+		AddTarget("root.txt", "target").
+		AddIgnore("ignored", "target/nested_ignored")
+
+	filepaths := []string{
+		"root.txt",
+		"ignored/ignored.txt",
+		"target/target.txt",
+		"target/nested/target.txt",
+		"target/nested_ignored/ignored.txt",
+	}
+
+	sut := setUp(t, filters, filepaths)
+	defer cleanUp(t)
+
+	sut.Import()
+
+	assertExists(t, vendorPath("root.txt"))
+	assertExists(t, vendorPath("target/target.txt"))
+	assertExists(t, vendorPath("target/nested/target.txt"))
+
+	assertNotExists(t, vendorPath("target/nested_ignored/ignored.txt"))
+}
+
+func assertExists(t *testing.T, filepath string) {
+	_, err := os.Stat(filepath)
+	assert.NoError(t, err, fmt.Sprintf("%q should exist, but it does not", filepath))
+}
+
+func assertNotExists(t *testing.T, filepath string) {
+	_, err := os.Stat(filepath)
+	assert.True(t, os.IsNotExist(err),
+		fmt.Sprintf("%q should not exist, but it does", filepath))
+}
+
+func vendorPath(filepath string) string {
+	return path.Join(VENDOR_DIR, filepath)
+}
+
+func setUp(t *testing.T, filters *vending.Filters, filepaths []string) *Importer {
+	os.MkdirAll(INPUT_DIR, os.ModePerm)
+	for _, filepath := range filepaths {
+		filepath := path.Join(INPUT_DIR, filepath)
+		os.MkdirAll(path.Dir(filepath), os.ModePerm)
+		_, err := os.Create(filepath)
+		assert.NoError(t, err)
+	}
+
+	spec := vending.NewSpec(nil)
+	spec.VendorDir = VENDOR_DIR
+	spec.Filters = filters
+
+	lock := lock.New(".testlock")
+	dep := vending.NewDependency("some-url", "some-branch")
+	repo := git.NewRepository(INPUT_DIR, lock, dep)
+	return New(repo, spec, dep)
+}
+
+func cleanUp(t *testing.T) {
+	os.RemoveAll(VENDOR_DIR)
+	os.RemoveAll(INPUT_DIR)
+}

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -8,9 +8,15 @@ import (
 
 	"github.com/alevinval/vendor-go/internal/git"
 	"github.com/alevinval/vendor-go/internal/lock"
+	"github.com/alevinval/vendor-go/pkg/log"
 	"github.com/alevinval/vendor-go/pkg/vending"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
 )
+
+func init() {
+	log.Level.SetLevel(zapcore.DebugLevel)
+}
 
 const VENDOR_DIR = ".testvendor"
 const INPUT_DIR = ".testinput"

--- a/internal/importer/selector.go
+++ b/internal/importer/selector.go
@@ -66,7 +66,9 @@ func hasPrefix(path string, prefixes []string) bool {
 }
 
 func inverseHasPrefix(paths []string, prefix string) bool {
+	prefix = normDir(prefix)
 	for _, path := range paths {
+		path = normDir(path)
 		if len(prefix) > len(path) {
 			path, prefix = prefix, path
 		}
@@ -75,4 +77,12 @@ func inverseHasPrefix(paths []string, prefix string) bool {
 		}
 	}
 	return false
+}
+
+func normDir(path string) string {
+	pathDir := filepath.Dir(path)
+	if pathDir == "." {
+		pathDir = path
+	}
+	return pathDir
 }

--- a/internal/importer/selector_test.go
+++ b/internal/importer/selector_test.go
@@ -42,6 +42,7 @@ func TestSelectorSelect_WithTargets(t *testing.T) {
 
 	assertSelection(t, sut, "nontarget/a/b", false, false)
 	assertSelection(t, sut, "ignored/a/b", false, false)
+	assertSelection(t, sut, "target", false, true)
 }
 
 func TestSelectorSelect_WithoutTargets(t *testing.T) {


### PR DESCRIPTION
Stop comparing filepaths directly, since we're only interested in
pruning a directory, the comparison between the path and the prefix
should contemplate only the directory, so now we only compare after
running `filepath.Dir`.