### PR TITLE
internal/importer: simplify, refine and clean-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ This tool allows users to install, manage and update dependencies. See the
 * Highly customizable tool: develop your custom presets, adapt, and standardize the
   vendoring process to your needs.
 
-* Parallelized vendoring process
+* Parallelized vendoring process: dependencies are vendored in parallel during install
+  or update operations, this further enhances speed due to the I/O required to clone or
+  fetch the upstreams.
 
 ## Usage
 

--- a/example/.vendor-lock.yml
+++ b/example/.vendor-lock.yml
@@ -1,4 +1,4 @@
-version: v0.4.0
+version: v0.4.5
 deps:
   - url: https://github.com/alevinval/ledger
     commit: 04abf50e06ae0dcf88e75cb35e922c7ae3aefad6

--- a/example/.vendor.yml
+++ b/example/.vendor.yml
@@ -1,4 +1,4 @@
-version: v0.4.0
+version: v0.4.5
 preset: default
 vendor_dir: vendor/
 extensions:

--- a/example/README.md
+++ b/example/README.md
@@ -3,25 +3,23 @@
 To generate the following example, the following commands have been executed:
 
 ```
-vendor init
+vending init
 
-[INFO] initializing vendor in current directory
-[INFO] .vendor.yml has been created
+.vendor.yml has been created
 ```
 
 ```
-vendor add https://github.com/alevinval/ledger --targets pkg/proto --targets README.md --extensions proto
+vending add https://github.com/alevinval/ledger master
 
-[INFO] added dependency https://github.com/alevinval/ledger@master
+added dependency https://github.com/alevinval/ledger@master
 ```
 
 ```
-vendor install
+vending install
 
-[INFO] installing https://github.com/alevinval/ledger@master
-[INFO] 	.../README.md -> vendor/README.md
-[INFO] 	.../pkg/proto/ledger.proto -> vendor/pkg/proto/ledger.proto
-[INFO] 	.../pkg/proto/checkpoint.proto -> vendor/pkg/proto/checkpoint.proto
-[INFO] 	🔒 04abf50e06ae0dcf88e75cb35e922c7ae3aefad6
-[INFO] install success ✅
+repository cache located at /Users/AlexandreVinyals/.vending-cache
+installing https://github.com/alevinval/ledger@04abf50e
+locking https://github.com/alevinval/ledger
+  🔒 04abf50e06ae0dcf88e75cb35e922c7ae3aefad6
+install success ✅
 ```

--- a/internal/importer/collector.go
+++ b/internal/importer/collector.go
@@ -27,7 +27,7 @@ func (tc *targetCollector) copyAll() error {
 	for _, target := range tc.targets {
 		err := target.copy()
 		if err != nil {
-			return fmt.Errorf("cannot copy target: %w", err)
+			return fmt.Errorf("cannot copy: %w", err)
 		}
 	}
 	return nil
@@ -39,11 +39,11 @@ func (t *target) copy() error {
 	dstDir := filepath.Dir(t.dst)
 	err := os.MkdirAll(dstDir, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("cannot create target path %q: %w", dstDir, err)
+		return fmt.Errorf("cannot create dstDir %q: %w", dstDir, err)
 	}
 	err = copyFile(t.src, t.dst)
 	if err != nil {
-		return fmt.Errorf("cannot copy file: %w", err)
+		return fmt.Errorf("cannot copyFile: %w", err)
 	}
 	return nil
 }

--- a/internal/importer/collector.go
+++ b/internal/importer/collector.go
@@ -14,9 +14,9 @@ type targetCollector struct {
 }
 
 type target struct {
-	src         string
-	dst         string
-	srcRelative string
+	src    string
+	srcRel string
+	dst    string
 }
 
 func (tc *targetCollector) add(t target) {
@@ -34,7 +34,7 @@ func (tc *targetCollector) copyAll() error {
 }
 
 func (t *target) copy() error {
-	log.S().Debugf("  [copy] ../%s -> %s", t.srcRelative, t.dst)
+	log.S().Debugf("  [copy] ../%s -> %s", t.srcRel, t.dst)
 
 	dstDir := filepath.Dir(t.dst)
 	err := os.MkdirAll(dstDir, os.ModePerm)

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -33,11 +33,11 @@ func New(repo *git.Repository, spec *vending.Spec, dep *vending.Dependency) *Imp
 func (imp *Importer) Import() error {
 	collector, err := imp.collect()
 	if err != nil {
-		return fmt.Errorf("cannot import: %w", err)
+		return fmt.Errorf("cannot collect: %w", err)
 	}
 	err = collector.copyAll()
 	if err != nil {
-		return fmt.Errorf("cannot import: %w", err)
+		return fmt.Errorf("cannot copyAll: %w", err)
 	}
 	return nil
 }
@@ -47,7 +47,7 @@ func (imp *Importer) collect() (*targetCollector, error) {
 	targetCollector := &targetCollector{targets: []target{}}
 
 	err := imp.repo.WalkDir(
-		collectPathsFunc(
+		collectTargetsFunc(
 			imp.repo.Path(),
 			imp.spec.VendorDir,
 			selector,
@@ -58,7 +58,11 @@ func (imp *Importer) collect() (*targetCollector, error) {
 	return targetCollector, err
 }
 
-func collectPathsFunc(srcRoot, dstRoot string, selector *Selector, collector *targetCollector) fs.WalkDirFunc {
+func collectTargetsFunc(
+	srcRoot, dstRoot string,
+	selector *Selector,
+	collector *targetCollector,
+) fs.WalkDirFunc {
 	return func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			log.S().Warnf("skipping directory %s due to path error: %w", path, err)

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -61,7 +61,8 @@ func (imp *Importer) collect() (*targetCollector, error) {
 func collectPathsFunc(srcRoot, dstRoot string, selector *Selector, collector *targetCollector) fs.WalkDirFunc {
 	return func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
-			return fmt.Errorf("path collection interrupted: %w", err)
+			log.S().Warnf("skipping directory %s due to path error: %w", path, err)
+			return nil
 		}
 
 		if strings.EqualFold(srcRoot, path) {

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -73,22 +73,22 @@ func collectTargetsFunc(
 			return nil
 		}
 
-		relativePath, err := filepath.Rel(srcRoot, path)
+		pathRel, err := filepath.Rel(srcRoot, path)
 		if err != nil {
 			return fmt.Errorf("cannot get relative path: %w", err)
 		}
 
-		if isSelected, shouldEnterDir := selector.Select(relativePath); isSelected {
+		if entry.IsDir() && !selector.SelectDir(pathRel) {
+			log.S().Debugf("  [skip] %s", pathRel)
+			return fs.SkipDir
+		} else if selector.SelectPath(pathRel) {
 			collector.add(
 				target{
-					srcRelative: relativePath,
-					src:         path,
-					dst:         filepath.Join(dstRoot, relativePath),
+					src:    path,
+					srcRel: pathRel,
+					dst:    filepath.Join(dstRoot, pathRel),
 				},
 			)
-		} else if entry.IsDir() && !shouldEnterDir {
-			log.S().Debugf("  [skip] %s", relativePath)
-			return fs.SkipDir
 		}
 
 		return nil

--- a/internal/importer/selector.go
+++ b/internal/importer/selector.go
@@ -19,15 +19,15 @@ func newSelector(spec *vending.Spec, dep *vending.Dependency) *Selector {
 	}
 }
 
-func (sel *Selector) Select(path string) (isSelected, shouldEnterDir bool) {
-	isIgnored := sel.isIgnored(path)
-	isSelected = sel.isTarget(path) && sel.hasExt(path) && !isIgnored
-	shouldEnterDir = !isIgnored && sel.shouldEnterDir(path)
-	return
+// SelectPath determines if a filepath should be selected or not.
+func (sel *Selector) SelectPath(path string) bool {
+	return sel.isTarget(path) && sel.hasExt(path) && !sel.isIgnored(path)
 }
 
-func (sel *Selector) shouldEnterDir(path string) bool {
-	return len(sel.filters.Targets) == 0 || inverseHasPrefix(sel.filters.Targets, path)
+// SelectDir determines if a directory should be walked or not.
+func (sel *Selector) SelectDir(dir string) bool {
+	return !sel.isIgnored(dir) && (len(sel.filters.Targets) == 0 ||
+		inverseHasPrefix(sel.filters.Targets, dir))
 }
 
 func (sel *Selector) isTarget(path string) bool {
@@ -65,6 +65,8 @@ func hasPrefix(path string, prefixes []string) bool {
 	return false
 }
 
+// inverseHasPrefix is used to determine when the WalkDirFunc should enter inside
+// a directory whenever a path has not been selected.
 func inverseHasPrefix(paths []string, prefix string) bool {
 	prefix = normDir(prefix)
 	for _, path := range paths {

--- a/internal/importer/selector_test.go
+++ b/internal/importer/selector_test.go
@@ -34,12 +34,14 @@ func TestSelectorSelect_WithTargets(t *testing.T) {
 		filters: filtersWithTargets,
 	}
 
+	// Filepaths
 	assertSelection(t, sut, "target/a/some-file.proto", true, true)
 	assertSelection(t, sut, "target/a/ignored/ignored.proto", false, false)
 	assertSelection(t, sut, "ignored/a/ignored.proto", false, false)
 	assertSelection(t, sut, "target/a/readme.md", false, true)
 	assertSelection(t, sut, "target/a/no-extension", false, true)
 
+	// Dirs
 	assertSelection(t, sut, "nontarget/a/b", false, false)
 	assertSelection(t, sut, "ignored/a/b", false, false)
 	assertSelection(t, sut, "target", false, true)
@@ -54,12 +56,14 @@ func TestSelectorSelect_WithoutTargets(t *testing.T) {
 		filters: filtersWithoutTargets,
 	}
 
+	// Filepaths
 	assertSelection(t, sut, "target/a/some-file.proto", true, true)
 	assertSelection(t, sut, "target/a/ignored/ignored.proto", false, false)
 	assertSelection(t, sut, "ignored/a/ignored.proto", false, false)
 	assertSelection(t, sut, "target/a/readme.md", false, true)
 	assertSelection(t, sut, "target/a/no-extension", false, true)
 
+	// Dirs
 	assertSelection(t, sut, "nontarget/a/b", false, true)
 	assertSelection(t, sut, "ignored/a/b", false, false)
 }
@@ -68,7 +72,8 @@ func assertSelection(
 	t *testing.T, sut Selector, path string,
 	expectedIsSelected, expectedShouldEnterDir bool,
 ) {
-	isSelected, shouldEnterDir := sut.Select(path)
+	isSelected := sut.SelectPath(path)
+	shouldEnterDir := sut.SelectDir(path)
 
 	assert.Equal(t, expectedIsSelected, isSelected, "isSelected missmatch")
 	assert.Equal(t, expectedShouldEnterDir, shouldEnterDir, "shouldEnterDir missmatch")

--- a/internal/installer/dependency.go
+++ b/internal/installer/dependency.go
@@ -95,7 +95,7 @@ func (d *dependencyInstaller) Update() (*vending.DependencyLock, error) {
 func (d *dependencyInstaller) importFiles() (*vending.DependencyLock, error) {
 	err := d.imp.Import()
 	if err != nil {
-		return nil, fmt.Errorf("cannot import files: %w", err)
+		return nil, fmt.Errorf("cannot import: %w", err)
 	}
 
 	commit, err := d.repo.GetCurrentCommit()

--- a/pkg/vending/filters.go
+++ b/pkg/vending/filters.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Filters is a collection type. When vendoring dependencies we look if the
-// file paths are copied or ignored, or wether the extension is supported.
+// file paths are copied or ignored, or whether the extension is supported.
 // Filters are directly serialized into the output YAML.
 //
 // Filters supposed to make life easier proving a builder pattern so it's

--- a/pkg/vending/presets.go
+++ b/pkg/vending/presets.go
@@ -31,7 +31,7 @@ type Preset interface {
 	// GetFiltersForDependency returns the specific filters for a dependency
 	GetFiltersForDependency(*Dependency) *Filters
 
-	// ForceFilters flag returns wether the preset will force the overriding of
+	// ForceFilters flag returns whether the preset will force the overriding of
 	// the spec or dependency filters to the preset ones
 	ForceFilters() bool
 

--- a/pkg/vending/spec.go
+++ b/pkg/vending/spec.go
@@ -11,7 +11,7 @@ import (
 )
 
 // VERSION of the current tool
-const VERSION = "v0.4.3"
+const VERSION = "v0.4.5"
 
 // Spec holds relevant information related to the specification of what
 // versions need to be fetched when updating dependencies.

--- a/pkg/vending/spec_lock_test.go
+++ b/pkg/vending/spec_lock_test.go
@@ -71,7 +71,7 @@ func TestSpecLock_SaveOutput(t *testing.T) {
 	err := sut.Save()
 	assert.NoError(t, err)
 
-	expected := `version: v0.4.3
+	expected := `version: v0.4.5
 deps:
   - url: some-url
     commit: some-commit

--- a/pkg/vending/spec_test.go
+++ b/pkg/vending/spec_test.go
@@ -184,7 +184,7 @@ func TestSpec_SaveOutput(t *testing.T) {
 	err := sut.Save()
 	assert.NoError(t, err)
 
-	expected := `version: v0.4.3
+	expected := `version: v0.4.5
 preset: test-preset
 vendor_dir: test-vendor-dir
 extensions:


### PR DESCRIPTION
- Now it logs a warning trace reporting the path that will be skipped, and immediately returns nil, so the Import operation continues.
- Improved error messages
- Split selection in two methods: one for paths, another for directories, importer runs minimum amount of logic depending on whether we are processing a filepath or a directory

Also address #4 