### PR TITLE
pkg/cmd: support providing filters via cobra flags

### DIFF
--- a/example/.vendor.yml
+++ b/example/.vendor.yml
@@ -1,8 +1,11 @@
 version: v0.4.5
 preset: default
 vendor_dir: vendor/
-extensions:
-  - proto
 deps:
   - url: https://github.com/alevinval/ledger
     branch: master
+    extensions:
+      - proto
+    targets:
+      - README.md
+      - pkg/proto

--- a/example/README.md
+++ b/example/README.md
@@ -9,7 +9,7 @@ vending init
 ```
 
 ```
-vending add https://github.com/alevinval/ledger master
+vending add https://github.com/alevinval/ledger master -t pkg/proto -t README.md -e proto
 
 added dependency https://github.com/alevinval/ledger@master
 ```

--- a/example/vendor/README.md
+++ b/example/vendor/README.md
@@ -1,0 +1,35 @@
+# Ledger
+
+This library implements an event log and imitates how kafka consumers work.
+Writers commit entries into the log, and readers consume events. Each reader
+can be configured to consume from the first offset, from the last offset
+or from a custom offset. Once a reader has a committed offset, when it is
+stopped/restarted, the reader will resume from the last committed offset.
+
+These are the basic building blocks:
+
+* `ledger.Writer` writes events to the log
+* `ledger.Reader` reads events from the event log
+* `ledger.Message` returned when reading, when the message is
+processed trigger a commit with `msg.Commit()` to advance the reader offset
+
+Additionally, there are:
+
+* `ledger.PartitionedWriter` which internally keeps as many logs
+as partitions. Uses a round-robin strategy to distribute the writes.
+* `ledger.PartitionedReader` which supports reading messages from
+the partitions, emitting them in the original write order
+
+The underlying storage is a badger key value store. Badger can be
+configured to persist on disk, or keep everything in memory.
+
+## Development
+
+Run tests with `go test --tags debug ...` to enable debug level logging
+
+## Re-generating protos
+
+Make sure you have `protoc-gen-go` and `protoc-gen-go-grpc`, follow this guide:
+https://grpc.io/docs/languages/go/quickstart/
+
+Then run `make compile-protos`

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -154,7 +154,7 @@ func (c *Controller) Update() error {
 }
 
 // AddDependency adds a new dependency into the spec file.
-func (c *Controller) AddDependency(url, branch string) error {
+func (c *Controller) AddDependency(url, branch string, filters *vending.Filters) error {
 	spec := vending.NewSpec(c.preset)
 	err := spec.Load()
 	if err != nil {
@@ -162,6 +162,8 @@ func (c *Controller) AddDependency(url, branch string) error {
 	}
 
 	dep := vending.NewDependency(url, branch)
+	dep.Filters.ApplyFilters(filters)
+
 	spec.AddDependency(dep)
 
 	err = spec.Save()


### PR DESCRIPTION
Now we can customize the filtes from the CLI, when adding a dependency simply provide
more flags (eg `vending add -t some-target -e proto -e md`)