### PR TITLE
internal/importer: improve selection logic for perfect target matches

### DIFF
--- a/internal/importer/selector.go
+++ b/internal/importer/selector.go
@@ -53,12 +53,24 @@ func (sel *Selector) hasExt(path string) bool {
 		}
 	}
 
-	return false
+	// Reaching this path means the file does not contain a supported extension
+	// Check for a perfect match between any of the targets, in which case we want
+	// to select the file anyway.
+	return hasPerfectMatch(path, sel.filters.Targets)
 }
 
 func hasPrefix(path string, prefixes []string) bool {
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPerfectMatch(path string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if path == prefix {
 			return true
 		}
 	}

--- a/internal/importer/selector_test.go
+++ b/internal/importer/selector_test.go
@@ -27,7 +27,7 @@ func TestSelector(t *testing.T) {
 func TestSelectorSelect_WithTargets(t *testing.T) {
 	filtersWithTargets := vending.NewFilters().
 		AddExtension("proto").
-		AddTarget("target/a").
+		AddTarget("target/a", "readme.md").
 		AddIgnore("ignored/a", "target/a/ignored")
 
 	sut := Selector{
@@ -40,6 +40,7 @@ func TestSelectorSelect_WithTargets(t *testing.T) {
 	assertSelection(t, sut, "ignored/a/ignored.proto", false, false)
 	assertSelection(t, sut, "target/a/readme.md", false, true)
 	assertSelection(t, sut, "target/a/no-extension", false, true)
+	assertSelection(t, sut, "readme.md", true, false)
 
 	// Dirs
 	assertSelection(t, sut, "nontarget/a/b", false, false)


### PR DESCRIPTION
Now we will select files that do not have a matching extension, but have a perfect match with any of the targets.